### PR TITLE
[PW_SID:381173] [next] Bluetooth: btrtl: fix incorrect skb allocation failure check


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+
+    - name: CI
+      uses: tedd-an/action-kernel-ci@dev
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,32 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron: "15,45 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluetooth-next"
+        for_upstream_branch: 'for-upstream'
+        workflow_branch: 'workflow'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Sync Patchwork
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        pw_exclude_str: 'BlueZ'
+        base_branch: 'workflow'
+        github_token: ${{ secrets.ACTION_TOKEN }}

--- a/drivers/bluetooth/btrtl.c
+++ b/drivers/bluetooth/btrtl.c
@@ -581,7 +581,7 @@ struct btrtl_device_info *btrtl_initialize(struct hci_dev *hdev,
 		cmd[1] = opcode >> 8;
 
 		skb = bt_skb_alloc(sizeof(cmd), GFP_KERNEL);
-		if (IS_ERR(skb))
+		if (!skb)
 			goto out_free;
 
 		skb_put_data(skb, cmd, sizeof(cmd));


### PR DESCRIPTION

From: Colin Ian King <colin.king@canonical.com>

Currently the check for a failed bt_skb_alloc allocation is incorrectly
checking using IS_ERR and this can lead to a null pointer dereference. Fix
this by checking for a null pointer return using the !skb idiom.

Addresses-Coverity: ("Dereference null return")
Fixes: 1996d9cad6ad ("Bluetooth: btrtl: Ask 8821C to drop old firmware")
Signed-off-by: Colin Ian King <colin.king@canonical.com>
