### PR TITLE
[PW_SID:426817] Bluetooth: btusb: Fix the autosuspend enable and disable


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v2
+      with:
+        repository: tedd-an/bluez
+        path: bluez
+
+    - name: Create output folder
+      run: |
+        mkdir results
+
+    - name: CI
+      uses: tedd-an/action-kernel-ci@dev
+      with:
+        src_path: src
+        bluez_path: bluez
+        output_path: results
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+
+    - name: Upload results
+      uses: actions/upload-artifact@v2
+      with:
+        name: tester-logs
+        path: results/
+        if-no-files-found: warn

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron: "20,50 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluetooth-next"
+        for_upstream_branch: 'for-upstream'
+        workflow_branch: 'workflow'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Patchwork
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        pw_exclude_str: 'BlueZ'
+        base_branch: 'workflow'
+        github_token: ${{ secrets.ACTION_TOKEN }}
+

--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -4840,8 +4840,8 @@ static int btusb_probe(struct usb_interface *intf,
 			data->diag = NULL;
 	}
 
-	if (enable_autosuspend)
-		usb_enable_autosuspend(data->udev);
+	if (!enable_autosuspend)
+		usb_disable_autosuspend(data->udev);
 
 	err = hci_register_dev(hdev);
 	if (err < 0)
@@ -4901,6 +4901,9 @@ static void btusb_disconnect(struct usb_interface *intf)
 		gpiod_put(data->reset_gpio);
 
 	hci_free_dev(hdev);
+
+	if (!enable_autosuspend)
+		usb_enable_autosuspend(data->udev);
 }
 
 #ifdef CONFIG_PM


### PR DESCRIPTION

I tried to disable the autosuspend on btusb through the module
parameter enable_autosuspend, this parameter is set to N, but the usb
bluetooth device is still runtime suspended.
$ cat /sys/module/btusb/parameters/enable_autosuspend
N
$ cat /sys/bus/usb/devices/3-10/power/runtime_status
suspended
$ cat /sys/bus/usb/devices/3-10/power/runtime_suspended_time
65187

We already set ".supports_autosuspend = 1" in the usb_driver, this
device will be set autosuspend enabled by usb core, we don't need
to call usb_enable_autosuspend() in the btusb_probe(). Instead if
users set the parameter enable_autosuspend to N, we need to call
usb_disable_autosuspend() in the btusb_probe(). After this change
and set the parameter to N, we could see the device is not runtime
suspended anymore.
$ cat /sys/module/btusb/parameters/enable_autosuspend
N
$ cat /sys/bus/usb/devices/3-10/power/runtime_status
active
$ cat /sys/bus/usb/devices/3-10/power/runtime_suspended_time
0

And if we disable the autosuspend in the btusb_probe(), we need to
enable the autosuspend in the disconnect(), this could guarantee
that the device could be runtime suspended after we rmmod the btusb.

Signed-off-by: Hui Wang <hui.wang@canonical.com>
