### PR TITLE
[PW_SID:430719] Add reset hci through mgmt experimental feature


### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v2
+      with:
+        repository: tedd-an/bluez
+        path: bluez
+
+    - name: Create output folder
+      run: |
+        mkdir results
+
+    - name: CI
+      uses: tedd-an/action-kernel-ci@dev
+      with:
+        src_path: src
+        bluez_path: bluez
+        output_path: results
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+
+    - name: Upload results
+      uses: actions/upload-artifact@v2
+      with:
+        name: tester-logs
+        path: results/
+        if-no-files-found: warn

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron: "20,50 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluetooth-next"
+        for_upstream_branch: 'for-upstream'
+        workflow_branch: 'workflow'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Patchwork
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        pw_exclude_str: 'BlueZ'
+        base_branch: 'workflow'
+        github_token: ${{ secrets.ACTION_TOKEN }}
+

--- a/include/net/bluetooth/hci_core.h
+++ b/include/net/bluetooth/hci_core.h
@@ -599,6 +599,7 @@ struct hci_dev {
 	int (*set_bdaddr)(struct hci_dev *hdev, const bdaddr_t *bdaddr);
 	void (*cmd_timeout)(struct hci_dev *hdev);
 	bool (*prevent_wake)(struct hci_dev *hdev);
+	int (*reset_hci)(struct hci_dev *hdev);
 };
 
 #define HCI_PHY_HANDLE(handle)	(handle & 0xff)


### PR DESCRIPTION

We have an annoying issue with Intel Bluetooth adapter, that is after
we update a firmware in the filessystem, and reboot the machine, the
driver will not load the new firmware since the adapter is already in
the operational mode instead of bootloader mode. we need to poweroff
the machine and cold boot it, and even on some desktops, we need to
wait for 10+ seconds between poweroff and the cold boot.

I wrote a patch for this issue last year, Marcel suggested that "we
should do it in a more generic way that resets the controller and puts
it into boot loader support if support. We can use the experimental
mgmt setting for this".

Here I wrote a new patch set according to Marcel's suggestion, a
generic reset hci method for all usb bluetooth adapters, it will reset
the adapter on the usb bus (similar to unbind the device and rebind
the device), and will call disconnect() and probe() in the btusb.c;
for Intel adapters, there is a specific method to reset the adapter
and put it into the bootloader mode.

This is the log I run reset_hci on machines with Qualcomm and CSR
adapters (generic reset hci method):
$ sudo ./btmgmt -i 0 exp-reset-hci
Reset hci feature successfully set
$ dmesg
[  110.116868] Bluetooth: hci0: urb 00000000e81d049e failed to resubmit (2)
[  110.232865] usb 3-6: reset full-speed USB device number 3 using xhci_hcd
[  110.358814] usb 3-6: device firmware changed
[  110.358949] usb 3-6: USB disconnect, device number 3
[  110.476527] usb 3-6: new full-speed USB device number 4 using xhci_hcd
[  110.603890] usb 3-6: New USB device found, idVendor=0cf3, idProduct=e005, bcdDevice= 0.01
[  110.603907] usb 3-6: New USB device strings: Mfr=0, Product=0, SerialNumber=0
[  110.662539] usb 3-6: USB disconnect, device number 4
[  110.913411] usb 3-6: new full-speed USB device number 5 using xhci_hcd
[...]
[  116.186419] usb 3-6: New USB device found, idVendor=0cf3, idProduct=e005, bcdDevice= 0.02
[  116.186434] usb 3-6: New USB device strings: Mfr=0, Product=0, SerialNumber=0



This is the log I run reset_hci on the machien with Intel adaper, this
adapter has specific method to reset to bootloader mode:
$ sudo ./btmgmt -i 0 exp-reset-hci
Reset hci feature successfully set
$ dmesg
[  100.843848] usb 3-10: USB disconnect, device number 4
[  100.844639] Bluetooth: hci0: FW download error recovery failed (-19)
[  101.252944] usb 3-10: new full-speed USB device number 5 using xhci_hcd
[  101.380862] usb 3-10: New USB device found, idVendor=8087, idProduct=0026, bcdDevice= 0.02
[  101.380872] usb 3-10: New USB device strings: Mfr=0, Product=0, SerialNumber=0
[  101.384448] Bluetooth: hci0: Bootloader revision 0.4 build 0 week 30 2018
[  101.385367] Bluetooth: hci0: Device revision is 2
[  101.385374] Bluetooth: hci0: Secure boot is enabled
[  101.385377] Bluetooth: hci0: OTP lock is enabled
[  101.385380] Bluetooth: hci0: API lock is enabled
[  101.385383] Bluetooth: hci0: Debug lock is disabled
[  101.385385] Bluetooth: hci0: Minimum firmware build 1 week 10 2014
[  101.385849] Bluetooth: hci0: Found device firmware: intel/ibt-19-0-4.sfi
[  103.206577] Bluetooth: hci0: Waiting for firmware download to complete
[  103.207382] Bluetooth: hci0: Firmware loaded in 1780489 usecs
[  103.207409] Bluetooth: hci0: Waiting for device to boot
[  103.222478] Bluetooth: hci0: Device booted in 14734 usecs
[  103.222595] Bluetooth: hci0: Found Intel DDC parameters: intel/ibt-19-0-4.ddc
[  103.224414] Bluetooth: hci0: Applying Intel DDC parameters completed
[  103.227429] Bluetooth: hci0: Firmware revision 0.0 build 121 week 36 2020


Hui Wang (3):
Bluetooth: btusb: Add reset_hci handler
Bluetooth: make experimental features expand easier
Bluetooth: reset_hci experimental feature

drivers/bluetooth/btusb.c        |  60 +++++
include/net/bluetooth/hci_core.h |   1 +
