### PR TITLE
[PW_SID:519481] Bluetooth: Support for LE Set Preferred PHY


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v2
+      with:
+        repository: tedd-an/bluez
+        path: bluez
+
+    - name: Create output folder
+      run: |
+        mkdir results
+
+    - name: CI
+      uses: tedd-an/action-kernel-ci@dev
+      with:
+        src_path: src
+        bluez_path: bluez
+        output_path: results
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+
+    - name: Upload results
+      uses: actions/upload-artifact@v2
+      with:
+        name: tester-logs
+        path: results/
+        if-no-files-found: warn

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron: "20,50 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluetooth-next"
+        for_upstream_branch: 'for-upstream'
+        workflow_branch: 'workflow'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Patchwork
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        pw_exclude_str: 'BlueZ'
+        base_branch: 'workflow'
+        github_token: ${{ secrets.ACTION_TOKEN }}
+

--- a/drivers/bluetooth/hci_h5.c
+++ b/drivers/bluetooth/hci_h5.c
@@ -916,6 +916,13 @@ out_free:
 
 static void h5_btrtl_open(struct h5 *h5)
 {
+	/*
+	 * Since h5_btrtl_resume() does a device_reprobe() the suspend handling
+	 * done by the hci_suspend_notifier is not necessary; it actually causes
+	 * delays and a bunch of errors to get logged, so disable it.
+	 */
+	set_bit(HCI_UART_NO_SUSPEND_NOTIFIER, &h5->hu->flags);
+
 	/* Devices always start with these fixed parameters */
 	serdev_device_set_flow_control(h5->hu->serdev, false);
 	serdev_device_set_parity(h5->hu->serdev, SERDEV_PARITY_EVEN);

--- a/drivers/bluetooth/hci_serdev.c
+++ b/drivers/bluetooth/hci_serdev.c
@@ -343,6 +343,9 @@ int hci_uart_register_device(struct hci_uart *hu,
 	hdev->setup = hci_uart_setup;
 	SET_HCIDEV_DEV(hdev, &hu->serdev->dev);
 
+	if (test_bit(HCI_UART_NO_SUSPEND_NOTIFIER, &hu->flags))
+		set_bit(HCI_QUIRK_NO_SUSPEND_NOTIFIER, &hdev->quirks);
+
 	if (test_bit(HCI_UART_RAW_DEVICE, &hu->hdev_flags))
 		set_bit(HCI_QUIRK_RAW_DEVICE, &hdev->quirks);
 

--- a/drivers/bluetooth/hci_uart.h
+++ b/drivers/bluetooth/hci_uart.h
@@ -86,9 +86,10 @@ struct hci_uart {
 };
 
 /* HCI_UART proto flag bits */
-#define HCI_UART_PROTO_SET	0
-#define HCI_UART_REGISTERED	1
-#define HCI_UART_PROTO_READY	2
+#define HCI_UART_PROTO_SET		0
+#define HCI_UART_REGISTERED		1
+#define HCI_UART_PROTO_READY		2
+#define HCI_UART_NO_SUSPEND_NOTIFIER	3
 
 /* TX states  */
 #define HCI_UART_SENDING	1

--- a/include/net/bluetooth/bluetooth.h
+++ b/include/net/bluetooth/bluetooth.h
@@ -140,6 +140,13 @@ struct bt_voice {
 #define BT_PHY_LE_2M_RX		0x00001000
 #define BT_PHY_LE_CODED_TX	0x00002000
 #define BT_PHY_LE_CODED_RX	0x00004000
+#define BT_PHY_LE_CODED_S2      0x00008000
+#define BT_PHY_LE_CODED_S8      0x00010000
+
+#define BT_PHY_LE_TX_MASK (BT_PHY_LE_1M_TX | BT_PHY_LE_2M_TX | \
+			     BT_PHY_LE_CODED_TX)
+#define BT_PHY_LE_RX_MASK (BT_PHY_LE_1M_RX | BT_PHY_LE_2M_RX | \
+			     BT_PHY_LE_CODED_RX)
 
 #define BT_MODE			15
 

--- a/include/net/bluetooth/hci.h
+++ b/include/net/bluetooth/hci.h
@@ -1677,9 +1677,21 @@ struct hci_cp_le_set_default_phy {
 	__u8    rx_phys;
 } __packed;
 
+#define HCI_OP_LE_SET_PHY	0x2032
+struct hci_cp_le_set_phy {
+	__le16	handle;
+	__u8	all_phys;
+	__u8	tx_phys;
+	__u8	rx_phys;
+	__le16	phy_opt;
+} __packed;
+
 #define HCI_LE_SET_PHY_1M		0x01
 #define HCI_LE_SET_PHY_2M		0x02
 #define HCI_LE_SET_PHY_CODED		0x04
+
+#define HCI_LE_PHY_CODED_S2		0x01
+#define HCI_LE_PHY_CODED_S8		0x02
 
 #define HCI_LE_READ_PHY_1M		0x01
 #define HCI_LE_READ_PHY_2M		0x02

--- a/include/net/bluetooth/hci.h
+++ b/include/net/bluetooth/hci.h
@@ -1670,6 +1670,18 @@ struct hci_rp_le_read_max_data_len {
 	__le16	rx_time;
 } __packed;
 
+#define HCI_OP_LE_READ_PHY	0x2030
+struct hci_cp_le_read_phy {
+	__le16 handle;
+} __packed;
+
+struct hci_rp_le_read_phy {
+	__u8	status;
+	__le16	handle;
+	__u8	tx_phy;
+	__u8	rx_phy;
+} __packed;
+
 #define HCI_OP_LE_SET_DEFAULT_PHY	0x2031
 struct hci_cp_le_set_default_phy {
 	__u8    all_phys;

--- a/include/net/bluetooth/hci.h
+++ b/include/net/bluetooth/hci.h
@@ -1681,6 +1681,10 @@ struct hci_cp_le_set_default_phy {
 #define HCI_LE_SET_PHY_2M		0x02
 #define HCI_LE_SET_PHY_CODED		0x04
 
+#define HCI_LE_READ_PHY_1M		0x01
+#define HCI_LE_READ_PHY_2M		0x02
+#define HCI_LE_READ_PHY_CODED		0x03
+
 #define HCI_OP_LE_SET_EXT_SCAN_PARAMS   0x2041
 struct hci_cp_le_set_ext_scan_params {
 	__u8    own_addr_type;

--- a/include/net/bluetooth/hci_core.h
+++ b/include/net/bluetooth/hci_core.h
@@ -1702,6 +1702,7 @@ struct sk_buff *hci_cmd_sync(struct hci_dev *hdev, u16 opcode, u32 plen,
 			     const void *param, u32 timeout);
 
 u32 hci_conn_get_phy(struct hci_conn *conn);
+int hci_conn_set_phy(struct hci_conn *conn, u32 phys);
 
 /* ----- HCI Sockets ----- */
 void hci_send_to_sock(struct hci_dev *hdev, struct sk_buff *skb);

--- a/include/net/bluetooth/hci_core.h
+++ b/include/net/bluetooth/hci_core.h
@@ -1835,6 +1835,7 @@ void mgmt_advertising_removed(struct sock *sk, struct hci_dev *hdev,
 			      u8 instance);
 void mgmt_adv_monitor_removed(struct hci_dev *hdev, u16 handle);
 int mgmt_phy_configuration_changed(struct hci_dev *hdev, struct sock *skip);
+void mgmt_le_phy_update(struct hci_dev *hdev, struct hci_conn *conn, u8 status);
 int mgmt_add_adv_patterns_monitor_complete(struct hci_dev *hdev, u8 status);
 int mgmt_remove_adv_monitor_complete(struct hci_dev *hdev, u8 status);
 

--- a/include/net/bluetooth/mgmt.h
+++ b/include/net/bluetooth/mgmt.h
@@ -1100,6 +1100,13 @@ struct mgmt_ev_controller_resume {
 	struct mgmt_addr_info addr;
 } __packed;
 
+#define MGMT_EV_LE_PHY_UPDATE_COMPLETE	0x002f
+struct mgmt_ev_le_phy_update_complete {
+	struct mgmt_addr_info addr;
+	__u8	status;
+	__le32	phys;
+} __packed;
+
 #define MGMT_WAKE_REASON_NON_BT_WAKE		0x0
 #define MGMT_WAKE_REASON_UNEXPECTED		0x1
 #define MGMT_WAKE_REASON_REMOTE_WAKE		0x2

--- a/net/bluetooth/hci_conn.c
+++ b/net/bluetooth/hci_conn.c
@@ -1915,22 +1915,19 @@ u32 hci_conn_get_phy(struct hci_conn *conn)
 		break;
 
 	case LE_LINK:
-		if (conn->le_tx_phy & HCI_LE_SET_PHY_1M)
+
+		if (conn->le_tx_phy == HCI_LE_READ_PHY_1M)
 			phys |= BT_PHY_LE_1M_TX;
-
-		if (conn->le_rx_phy & HCI_LE_SET_PHY_1M)
-			phys |= BT_PHY_LE_1M_RX;
-
-		if (conn->le_tx_phy & HCI_LE_SET_PHY_2M)
+		else if (conn->le_tx_phy == HCI_LE_READ_PHY_2M)
 			phys |= BT_PHY_LE_2M_TX;
-
-		if (conn->le_rx_phy & HCI_LE_SET_PHY_2M)
-			phys |= BT_PHY_LE_2M_RX;
-
-		if (conn->le_tx_phy & HCI_LE_SET_PHY_CODED)
+		else if (conn->le_tx_phy == HCI_LE_READ_PHY_CODED)
 			phys |= BT_PHY_LE_CODED_TX;
 
-		if (conn->le_rx_phy & HCI_LE_SET_PHY_CODED)
+		if (conn->le_rx_phy == HCI_LE_READ_PHY_1M)
+			phys |= BT_PHY_LE_1M_RX;
+		else if (conn->le_rx_phy == HCI_LE_READ_PHY_2M)
+			phys |= BT_PHY_LE_2M_RX;
+		else if (conn->le_rx_phy == HCI_LE_READ_PHY_CODED)
 			phys |= BT_PHY_LE_CODED_RX;
 
 		break;

--- a/net/bluetooth/hci_event.c
+++ b/net/bluetooth/hci_event.c
@@ -5970,17 +5970,18 @@ static void hci_le_phy_update_evt(struct hci_dev *hdev, struct sk_buff *skb)
 
 	BT_DBG("%s status 0x%2.2x", hdev->name, ev->status);
 
-	if (ev->status)
-		return;
-
 	hci_dev_lock(hdev);
 
 	conn = hci_conn_hash_lookup_handle(hdev, __le16_to_cpu(ev->handle));
 	if (!conn)
 		goto unlock;
 
-	conn->le_tx_phy = ev->tx_phy;
-	conn->le_rx_phy = ev->rx_phy;
+	if (!ev->status) {
+		conn->le_tx_phy = ev->tx_phy;
+		conn->le_rx_phy = ev->rx_phy;
+	}
+
+	mgmt_le_phy_update(hdev, conn, ev->status);
 
 unlock:
 	hci_dev_unlock(hdev);

--- a/net/bluetooth/l2cap_sock.c
+++ b/net/bluetooth/l2cap_sock.c
@@ -875,7 +875,7 @@ static int l2cap_sock_setsockopt(struct socket *sock, int level, int optname,
 	struct bt_power pwr;
 	struct l2cap_conn *conn;
 	int len, err = 0;
-	u32 opt;
+	u32 opt, phys;
 
 	BT_DBG("sk %p", sk);
 
@@ -1069,6 +1069,25 @@ static int l2cap_sock_setsockopt(struct socket *sock, int level, int optname,
 		else
 			chan->imtu = opt;
 
+		break;
+
+	case BT_PHY:
+		if (sk->sk_state != BT_CONNECTED) {
+			err = -ENOTCONN;
+			break;
+		}
+
+		if (copy_from_sockptr(&phys, optval, sizeof(u32))) {
+			err = -EFAULT;
+			break;
+		}
+
+		err = hci_conn_set_phy(chan->conn->hcon, phys);
+
+		if (err)
+			break;
+
+		BT_DBG("phys %u", phys);
 		break;
 
 	case BT_MODE:


### PR DESCRIPTION

Hello Maintainers,

This patch set fixes some minor bugs and adds support for
BT 5.0 PHY based HCI command "HCI_OP_LE_SET_PHY" to request
controller to change connection specific PHY settings
(2M PHY, coded PHY etc.).

Ayush Garg (4):
Bluetooth: Fix incorrect parsing of LE_PHY params
Bluetooth: Implement BT_PHY setsocket option
Bluetooth: Add support for sending LE PHY Update event over mgmt
Bluetooth: Update LE TX & RX PHYs when connection established

include/net/bluetooth/bluetooth.h |  7 +++
include/net/bluetooth/hci.h       | 28 +++++++++++
include/net/bluetooth/hci_core.h  |  2 +
include/net/bluetooth/mgmt.h      |  7 +++
