### PR TITLE
[PW_SID:553795] Bluetooth: msft: Fix build when BT_MSFTEXT is not defined


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v2
+      with:
+        repository: tedd-an/bluez
+        path: bluez
+
+    - name: Create output folder
+      run: |
+        mkdir results
+
+    - name: CI
+      uses: tedd-an/action-kernel-ci@dev
+      with:
+        src_path: src
+        bluez_path: bluez
+        output_path: results
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+
+    - name: Upload results
+      uses: actions/upload-artifact@v2
+      with:
+        name: tester-logs
+        path: results/
+        if-no-files-found: warn

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron: "20,50 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluetooth-next"
+        for_upstream_branch: 'for-upstream'
+        workflow_branch: 'workflow'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Patchwork
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        pw_exclude_str: 'BlueZ'
+        base_branch: 'workflow'
+        github_token: ${{ secrets.ACTION_TOKEN }}
+

--- a/net/bluetooth/mgmt.c
+++ b/net/bluetooth/mgmt.c
@@ -8469,7 +8469,7 @@ static int remove_advertising(struct sock *sk, struct hci_dev *hdev,
 	 * advertising.
 	 */
 	if (hci_dev_test_flag(hdev, HCI_ENABLE_LL_PRIVACY))
-		return mgmt_cmd_status(sk, hdev->id, MGMT_OP_SET_ADVERTISING,
+		return mgmt_cmd_status(sk, hdev->id, MGMT_OP_REMOVE_ADVERTISING,
 				       MGMT_STATUS_NOT_SUPPORTED);
 
 	hci_dev_lock(hdev);

--- a/net/bluetooth/msft.h
+++ b/net/bluetooth/msft.h
@@ -24,6 +24,8 @@ int msft_remove_monitor(struct hci_dev *hdev, struct adv_monitor *monitor,
 			u16 handle);
 void msft_req_add_set_filter_enable(struct hci_request *req, bool enable);
 int msft_set_filter_enable(struct hci_dev *hdev, bool enable);
+void msft_suspend(struct hci_dev *hdev);
+void msft_resume(struct hci_dev *hdev);
 bool msft_curve_validity(struct hci_dev *hdev);
 
 #else
@@ -58,6 +60,9 @@ static inline int msft_set_filter_enable(struct hci_dev *hdev, bool enable)
 {
 	return -EOPNOTSUPP;
 }
+
+void msft_suspend(struct hci_dev *hdev) {}
+void msft_resume(struct hci_dev *hdev) {}
 
 static inline bool msft_curve_validity(struct hci_dev *hdev)
 {

--- a/net/bluetooth/msft.h
+++ b/net/bluetooth/msft.h
@@ -61,8 +61,8 @@ static inline int msft_set_filter_enable(struct hci_dev *hdev, bool enable)
 	return -EOPNOTSUPP;
 }
 
-void msft_suspend(struct hci_dev *hdev) {}
-void msft_resume(struct hci_dev *hdev) {}
+static inline void msft_suspend(struct hci_dev *hdev) {}
+static inline void msft_resume(struct hci_dev *hdev) {}
 
 static inline bool msft_curve_validity(struct hci_dev *hdev)
 {


### PR DESCRIPTION

From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

ld: net/bluetooth/hci_event.o: in function `msft_suspend':
/linux/net/bluetooth/msft.h:64: multiple definition of `msft_suspend';
net/bluetooth/hci_core.o:/linux/net/bluetooth/msft.h:64: first defined here
ld: net/bluetooth/hci_event.o: in function `msft_resume':
/linux/net/bluetooth/msft.h:64: multiple definition of `msft_resume';
net/bluetooth/hci_core.o:/linux/net/bluetooth/msft.h:64: first defined here
ld: net/bluetooth/mgmt.o: in function `msft_suspend':
/linux/net/bluetooth/msft.h:64: multiple definition of `msft_suspend';
net/bluetooth/hci_core.o:/linux/net/bluetooth/msft.h:64: first defined here
ld: net/bluetooth/mgmt.o: in function `msft_resume':
/linux/net/bluetooth/msft.h:64: multiple definition of `msft_resume';
net/bluetooth/hci_core.o:/linux/net/bluetooth/msft.h:64: first defined here
ld: net/bluetooth/hci_request.o: in function `msft_suspend':
/linux/net/bluetooth/msft.h:64: multiple definition of `msft_suspend';
net/bluetooth/hci_core.o:/linux/net/bluetooth/msft.h:64: first defined here
ld: net/bluetooth/hci_request.o: in function `msft_resume':
/linux/net/bluetooth/msft.h:64: multiple definition of `msft_resume';
net/bluetooth/hci_core.o:/linux/net/bluetooth/msft.h:64: first defined here
make: *** [Makefile:1176: vmlinux] Error 1

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
