### PR TITLE
[PW_SID:555985] Detailed error string


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v2
+      with:
+        repository: tedd-an/bluez
+        path: bluez
+
+    - name: Create output folder
+      run: |
+        mkdir results
+
+    - name: CI
+      uses: tedd-an/action-kernel-ci@dev
+      with:
+        src_path: src
+        bluez_path: bluez
+        output_path: results
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+
+    - name: Upload results
+      uses: actions/upload-artifact@v2
+      with:
+        name: tester-logs
+        path: results/
+        if-no-files-found: warn

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron: "20,50 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluetooth-next"
+        for_upstream_branch: 'for-upstream'
+        workflow_branch: 'workflow'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Patchwork
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        pw_exclude_str: 'BlueZ'
+        base_branch: 'workflow'
+        github_token: ${{ secrets.ACTION_TOKEN }}
+

--- a/doc/errors.txt
+++ b/doc/errors.txt
@@ -1,0 +1,233 @@
+D-Bus Method Return Error Codes
+===============================
+
+The motivation of having detailed error is to provide context-based failure
+reasons along with D-Bus method return so that D-Bus clients can build metrics
+and optimize their application based on these failure reasons. For instance, a
+client can build retry mechanism for a connection failure or improve the
+bottleneck of use scenario based on actionable metrics.
+
+These error codes are context-based but not necessarily tied to interface or
+method calls. For instance, if a pairing request failed due to connection
+failure, connection error would be attached to the method return of Pair().
+
+BR/EDR connection already connected
+===================================
+	errno:	EALREADY, EISCONN
+
+	Either the profile is already connected or ACL connection is in place.
+
+BR/EDR connection page timeout
+==============================
+	errno:	EHOSTDOWN
+
+	Failed due to page timeout.
+
+BR/EDR connection profile unavailable
+=====================================
+	errno:	ENOPROTOOPT
+
+	Failed to find connectable services or the target service.
+
+BR/EDR connection SDP search
+============================
+	errno:	none
+
+	Failed to complete the SDP search.
+
+BR/EDR connection create socket
+===============================
+	errno:	EIO
+
+	Failed to create or connect to BT IO socket. This can also indicate
+	hardware failure in the controller.
+
+BR/EDR connection invalid arguments
+===================================
+	errno:	EHOSTUNREACH
+
+	Failed due to invalid arguments.
+
+BR/EDR connection not powered
+=============================
+	errno:	EHOSTUNREACH
+
+	Failed due to adapter not powered.
+
+BR/EDR connection not supported
+===============================
+	errno:	EOPNOTSUPP, EPROTONOSUPPORT
+
+	Failed due to unsupported state transition of L2CAP channel or other
+	features either by the local host or the remote.
+
+BR/EDR connection bad socket
+============================
+	errno:	EBADFD
+
+	Failed due to the socket is in bad state.
+
+BR/EDR connection memory allocation
+===================================
+	errno:	ENOMEM
+
+	Failed to allocate memory in either host stack or controller.
+
+BR/EDR connection busy
+======================
+	errno:	EBUSY
+
+	Failed due to other ongoing operations, such as pairing, busy L2CAP
+	channel or the operation disallowed by the controller.
+
+BR/EDR connection concurrent connection limit
+=============================================
+	errno:	EMLINK
+
+	Failed due to reaching the concurrent connection limit to a device.
+
+BR/EDR connection timeout
+=========================
+	errno:	ETIMEDOUT
+
+	Failed due to connection timeout
+
+BR/EDR connection refused
+=========================
+	errno:	ECONNREFUSED
+
+	Refused by the remote device due to limited resource, security reason
+	or unacceptable address type.
+
+BR/EDR connection aborted by remote
+===================================
+	errno:	ECONNRESET
+
+	Terminated by the remote device due to limited resource or power off.
+
+BR/EDR connection aborted by local
+==================================
+	errno:	ECONNABORTED
+
+	Aborted by the local host.
+
+BR/EDR connection LMP protocol error
+====================================
+	errno:	EPROTO
+
+	Failed due to LMP protocol error.
+
+BR/EDR connection canceled
+==========================
+	errno:	none
+
+	Failed due to cancellation caused by adapter drop, unexpected device
+	drop, orincoming disconnection request before connection request is
+	completed.
+
+BR/EDR connection unknown error
+===============================
+	errno:	ENOSYS
+
+	Failed due to unknown reason.
+
+LE connection invalid arguments
+===============================
+	errno:	EINVAL
+
+	Failed due to invalid arguments.
+
+LE connection not powered
+=========================
+	errno:	EHOSTUNREACH
+
+	Failed due to adapter not powered.
+
+LE connection not supported
+===========================
+	errno:	EOPNOTSUPP, EPROTONOSUPPORT
+
+	Failed due to unsupported state transition of L2CAP channel or other
+	features (e.g. LE features) either by the local host or the remote.
+
+LE connection already connected
+===============================
+	errno: EALREADY, EISCONN
+
+	Either the BT IO is already connected or LE link connection in place.
+
+LE connection bad socket
+========================
+	errno: EBADFD
+
+	Failed due to the socket is in bad state.
+
+LE connection memory allocation
+===============================
+	errno: ENOMEM
+
+	Failed to allocate memory in either host stack or controller.
+
+LE connection busy
+==================
+	errno:	EBUSY
+
+	Failed due to other ongoing operations, such as pairing, connecting,
+	busy L2CAP channel or the operation disallowed by the controller.
+
+LE connection refused
+=====================
+	errno:	ECONNREFUSED
+
+	Failed due to that LE is not enabled or the attempt is refused by the
+	remote device due to limited resource, security reason or unacceptable
+	address type.
+
+LE connection create socket
+===========================
+	errno:	EIO
+
+	Failed to create or connect to BT IO socket. This can also indicate
+	hardware failure in the controller.
+
+LE connection timeout
+=====================
+	errno:	ETIMEDOUT
+
+	Failed due to connection timeout
+
+LE connection concurrent connection limit
+=========================================
+	errno:	EMLINK
+
+	Failed due to reaching the synchronous connection limit to a device.
+
+LE connection abort by remote
+=============================
+	errno:	ECONNRESET
+
+	Aborted by the remote device due to limited resource or power off.
+
+LE connection abort by local
+============================
+	errno:	ECONNABORTED
+
+	Aborted by the local host.
+
+LE connection link layer protocol error
+=======================================
+	errno:	EPROTO
+
+	Failed due to link layer protocol error.
+
+LE connection GATT browsing
+===========================
+	errno:	none
+
+	Failed to complete the GATT browsing.
+
+LE connection unknown error
+===========================
+	errno:	ENOSYS
+
+	Failed due to unknown reason.


### PR DESCRIPTION

Chromium OS has been working closely with Linux Bluetooth community to
improve BlueZ stack, and there are increasing needs from applications
building their features around Bluetooth. One of the major feedback
from these application is the lack of the detailed failure reasons as
return for D-Bus method call, and these failure reasons can be used in
metrics, optimizing retry mechanism, hinting the reproduce scenario to
improve BlueZ stack. The current org.bluez.Error.* are serving the
generic errors well. However,g given org.bluez.Error.* errors are used
across different interface context which does not serve the detailed
failure reasons well. (See https://github.com/bluez/bluez/issues/131)

Changes in v7:
- Fix nits

Changes in v6:
- Rephrase error string

Changes in v5:
- Replace error code with error string

Changes in v4:
- Address make errors.

Changes in v3:
- Correct error-codes.txt.

Changes in v2:
- Add documentation for error codes

Miao-chen Chou (4):
Add errors.txt to describe errors of D-Bus method returns
BR/EDR and LE connection failure reasons
Include detailed error string in Connect() return
Print error code for connect methods

client/main.c  |   3 +-
doc/errors.txt | 233 +++++++++++++++++++++++++++++++++++++++++++++++++
