### PR TITLE
[PW_SID:595033] Bluetooth: mgmt: Fix mgmt_device_found panic


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v2
+      with:
+        repository: tedd-an/bluez
+        path: bluez
+
+    - name: Create output folder
+      run: |
+        mkdir results
+
+    - name: CI
+      uses: tedd-an/action-kernel-ci@dev
+      with:
+        src_path: src
+        bluez_path: bluez
+        output_path: results
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+
+    - name: Upload results
+      uses: actions/upload-artifact@v2
+      with:
+        name: tester-logs
+        path: results/
+        if-no-files-found: warn

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron: "20,50 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluetooth-next"
+        for_upstream_branch: 'for-upstream'
+        workflow_branch: 'workflow'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Patchwork
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        pw_exclude_str: 'BlueZ'
+        base_branch: 'workflow'
+        github_token: ${{ secrets.ACTION_TOKEN }}
+

--- a/net/bluetooth/mgmt.c
+++ b/net/bluetooth/mgmt.c
@@ -9604,7 +9604,7 @@ void mgmt_device_found(struct hci_dev *hdev, bdaddr_t *bdaddr, u8 link_type,
 
 	/* Allocate skb. The 5 extra bytes are for the potential CoD field */
 	skb = mgmt_alloc_skb(hdev, MGMT_EV_DEVICE_FOUND,
-			     sizeof(ev) + eir_len + scan_rsp_len + 5);
+			     sizeof(*ev) + eir_len + scan_rsp_len + 5);
 	if (!skb)
 		return;
 
@@ -9636,7 +9636,7 @@ void mgmt_device_found(struct hci_dev *hdev, bdaddr_t *bdaddr, u8 link_type,
 
 		eir_len += eir_append_data(eir_cod, 0, EIR_CLASS_OF_DEV,
 					   dev_class, 3);
-		skb_put_data(skb, eir_cod, eir_len);
+		skb_put_data(skb, eir_cod, sizeof(eir_cod));
 	}
 
 	if (scan_rsp_len > 0)


### PR DESCRIPTION

From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This fixes the following buffer overflow when Class of Device is
missing:

skbuff: skb_over_panic: text:ffffffff8b70f8c0 len:335 put:163
head:ffff888001388000 data:ffff888001388006 tail:0x155 end:0xc0
dev:<NULL>
kernel BUG at net/core/skbuff.c:113!
invalid opcode: 0000 [#1] PREEMPT KASAN PTI
CPU: 0 PID: 51 Comm: kworker/u3:2 Not tainted
5.16.0-rc1-14427-g77755dc54f9e-dirty #2795
Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS 1.14.0-6.fc35
04/01/2014
Workqueue: hci0 hci_rx_work
RIP: 0010:skb_panic+0xc7/0xc9
Code: 89 f0 48 c7 c7 00 d7 d5 8b 55 48 8b 74 24 18 4d 89 f9 56 48 8b 54
24 18 4c 89 e6 52 48 8b 44 24 18 4c 89 ea 50 e8 80 ac fd ff <0f> 0b 48
c7 c6 60 e0 d5 8b 48 c7 c7 9
RSP: 0018:ffff88800181fa08 EFLAGS: 00010286
RAX: 0000000000000088 RBX: ffff88800197c600 RCX: 0000000000000000
RDX: 0000000000000001 RSI: 0000000000000008 RDI: ffffed1000303f34
RBP: ffffffff8bd5d6c0 R08: 0000000000000088 R09: ffff88800181f6a7
R10: ffffed1000303ed4 R11: 0000000000000001 R12: ffffffff8bd5dfa0
R13: ffffffff8b70f8c0 R14: 00000000000000a3 R15: ffff888001388000
FS:  0000000000000000(0000) GS:ffffffff8c097000(0000) knlGS:0000000000000000
CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
CR2: 00007f235d05519d CR3: 00000000018c8000 CR4: 00000000000006f0
DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
Call Trace:
<TASK>
? mgmt_device_found+0x5c0/0x680
skb_put.cold+0x1f/0x1f
mgmt_device_found+0x5c0/0x680
? kasan_unpoison+0x23/0x50
? mgmt_set_local_name_complete+0x1d0/0x1d0
? hci_inquiry_cache_update+0x51/0x3e0
hci_extended_inquiry_result_evt+0x2e9/0x3d0
? hci_inquiry_result_evt+0x280/0x280
? mutex_unlock+0x7a/0xc0
? mutex_lock+0xd0/0xd0
? bt_dbg_get+0x10/0x10
hci_event_packet+0x4a7/0x720
? hci_inquiry_result_evt+0x280/0x280
? hci_encrypt_change_evt+0x970/0x970
? skb_release_data+0x9d/0x230
hci_rx_work+0x134/0x450
? read_word_at_a_time+0xe/0x20
? strscpy+0xb5/0x190
process_one_work+0x435/0x690
worker_thread+0x2c7/0x7e0
? process_one_work+0x690/0x690
kthread+0x20e/0x240
? set_kthread_struct+0x80/0x80
ret_from_fork+0x22/0x30
</TASK>
