### PR TITLE
[PW_SID:603038] Bluetooth: hci_event: Rework hci_inquiry_result_with_rssi_evt


### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        path: src
+
+    - name: Checkout the BlueZ source code
+      uses: actions/checkout@v2
+      with:
+        repository: tedd-an/bluez
+        path: bluez
+
+    - name: Create output folder
+      run: |
+        mkdir results
+
+    - name: CI
+      uses: tedd-an/action-kernel-ci@dev
+      with:
+        src_path: src
+        bluez_path: bluez
+        output_path: results
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        email_token: ${{ secrets.EMAIL_TOKEN }}
+        patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+
+    - name: Upload results
+      uses: actions/upload-artifact@v2
+      with:
+        name: tester-logs
+        path: results/
+        if-no-files-found: warn

--- a/.github/workflows/schedule_work.yml
+++ b/.github/workflows/schedule_work.yml
@@ -1,0 +1,35 @@
+name: Scheduled Work
+
+on:
+  schedule:
+  - cron: "20,50 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Repo
+      uses: tedd-an/action-manage-repo@master
+      with:
+        src_repo: "bluez/bluetooth-next"
+        for_upstream_branch: 'for-upstream'
+        workflow_branch: 'workflow'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Sync Patchwork
+      uses: tedd-an/action-patchwork-to-pr@master
+      with:
+        pw_exclude_str: 'BlueZ'
+        base_branch: 'workflow'
+        github_token: ${{ secrets.ACTION_TOKEN }}
+

--- a/include/net/bluetooth/hci.h
+++ b/include/net/bluetooth/hci.h
@@ -2233,11 +2233,7 @@ struct inquiry_info_rssi_pscan {
 } __packed;
 struct hci_ev_inquiry_result_rssi {
 	__u8     num;
-	struct inquiry_info_rssi info[];
-} __packed;
-struct hci_ev_inquiry_result_rssi_pscan {
-	__u8     num;
-	struct inquiry_info_rssi_pscan info[];
+	__u8     data[];
 } __packed;
 
 #define HCI_EV_REMOTE_EXT_FEATURES	0x23

--- a/net/bluetooth/hci_event.c
+++ b/net/bluetooth/hci_event.c
@@ -4507,16 +4507,13 @@ static void hci_pscan_rep_mode_evt(struct hci_dev *hdev, void *data,
 static void hci_inquiry_result_with_rssi_evt(struct hci_dev *hdev, void *edata,
 					     struct sk_buff *skb)
 {
-	union {
-		struct hci_ev_inquiry_result_rssi *res1;
-		struct hci_ev_inquiry_result_rssi_pscan *res2;
-	} *ev = edata;
+	struct hci_ev_inquiry_result_rssi *ev = edata;
 	struct inquiry_data data;
 	int i;
 
-	bt_dev_dbg(hdev, "num_rsp %d", ev->res1->num);
+	bt_dev_dbg(hdev, "num_rsp %d", ev->num);
 
-	if (!ev->res1->num)
+	if (!ev->num)
 		return;
 
 	if (hci_dev_test_flag(hdev, HCI_PERIODIC_INQ))
@@ -4524,10 +4521,11 @@ static void hci_inquiry_result_with_rssi_evt(struct hci_dev *hdev, void *edata,
 
 	hci_dev_lock(hdev);
 
-	if (skb->len == flex_array_size(ev, res2->info, ev->res2->num)) {
+	if (skb->len == array_size(ev->num,
+				   sizeof(struct inquiry_info_rssi_pscan))) {
 		struct inquiry_info_rssi_pscan *info;
 
-		for (i = 0; i < ev->res2->num; i++) {
+		for (i = 0; i < ev->num; i++) {
 			u32 flags;
 
 			info = hci_ev_skb_pull(hdev, skb,
@@ -4554,10 +4552,11 @@ static void hci_inquiry_result_with_rssi_evt(struct hci_dev *hdev, void *edata,
 					  info->dev_class, info->rssi,
 					  flags, NULL, 0, NULL, 0);
 		}
-	} else if (skb->len == flex_array_size(ev, res1->info, ev->res1->num)) {
+	} else if (skb->len == array_size(ev->num,
+					  sizeof(struct inquiry_info_rssi))) {
 		struct inquiry_info_rssi *info;
 
-		for (i = 0; i < ev->res1->num; i++) {
+		for (i = 0; i < ev->num; i++) {
 			u32 flags;
 
 			info = hci_ev_skb_pull(hdev, skb,


### PR DESCRIPTION

From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This rework the handling of hci_inquiry_result_with_rssi_evt to not use
a union to represent the different inquiry responses.

Tested-by: Soenke Huster <soenke.huster@eknoes.de>
Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
