### PR TITLE
[PW_SID:693538] Bluetooth: selftest: Fix memleak in test_ecdh()

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          path: src/src
+
+      - name: CI
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: ci
+          base_folder: src
+          space: kernel
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,36 @@
+name: Snyc
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Sync Repo
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: sync
+          upstream_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sync Patchwork
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: patchwork
+          space: kernel
+          github_token: ${{ secrets.ACTION_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/net/bluetooth/selftest.c
+++ b/net/bluetooth/selftest.c
@@ -233,8 +233,6 @@ static int __init test_ecdh(void)
 		goto done;
 	}
 
-	crypto_free_kpp(tfm);
-
 	rettime = ktime_get();
 	delta = ktime_sub(rettime, calltime);
 	duration = (unsigned long long) ktime_to_ns(delta) >> 10;
@@ -247,6 +245,8 @@ done:
 			 "PASS (%llu usecs)\n", duration);
 	else
 		snprintf(test_ecdh_buffer, sizeof(test_ecdh_buffer), "FAIL\n");
+
+	crypto_free_kpp(tfm);
 
 	debugfs_create_file("selftest_ecdh", 0444, bt_debugfs, NULL,
 			    &test_ecdh_fops);


### PR DESCRIPTION
kmemleak reported:
 Bluetooth: ECDH sample 1 failed
 kmemleak: 2 new suspected memory leaks (see /sys/kernel/debug/kmemleak)
 unreferenced object 0xffff888102149100 (size 96):
  comm "modprobe", pid 418, jiffies 4295082093 (age 610.644s)
  ...
  backtrace:
    [<00000000c8e4e5a6>] __kmalloc_node+0x4c/0x1c0
    [<000000006cdcfddc>] crypto_create_tfm_node+0x89/0x320
    [<00000000e222ad46>] crypto_alloc_tfm_node+0xfd/0x2f0
    [<00000000871fc045>] 0xffffffffc05c94ab
    [<00000000e889f45e>] 0xffffffffc05c8024
    [<000000001ff0c346>] do_one_initcall+0xd0/0x4e0
  ...

In test_ecdh(), when test sample fails, crypto_free_kpp(tfm) is not
called, which makes tfm memory leaked. Fix it by moving crypto_free_kpp
behind done label.

Fixes: 47eb2ac80918 ("Bluetooth: move ecdh allocation outside of ecdh_helper")
Signed-off-by: Chen Zhongjin <chenzhongjin@huawei.com>
---
 net/bluetooth/selftest.c | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)