### PR TITLE
[PW_SID:729360] Bluetooth: 6LoWPAN: Add missing check for skb_clone

### DIFF
--- a/net/bluetooth/6lowpan.c
+++ b/net/bluetooth/6lowpan.c
@@ -477,6 +477,10 @@ static int send_mcast_pkt(struct sk_buff *skb, struct net_device *netdev)
 			int ret;
 
 			local_skb = skb_clone(skb, GFP_ATOMIC);
+			if (!local_skb) {
+				rcu_read_unlock();
+				return -ENOMEM;
+			}
 
 			BT_DBG("xmit %s to %pMR type %u IP %pI6c chan %p",
 			       netdev->name,


### PR DESCRIPTION
Add the check for the return value of skb_clone since it may return NULL
pointer and cause NULL pointer dereference in send_pkt.

Fixes: 18722c247023 ("Bluetooth: Enable 6LoWPAN support for BT LE devices")
Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>
---
 net/bluetooth/6lowpan.c | 4 ++++
 1 file changed, 4 insertions(+)