### PR TITLE
[PW_SID:736842] Set ISO Data Path on broadcast sink

### DIFF
--- a/net/bluetooth/hci_event.c
+++ b/net/bluetooth/hci_event.c
@@ -6997,6 +6997,7 @@ static void hci_le_big_sync_established_evt(struct hci_dev *hdev, void *data,
 		bis->iso_qos.bcast.in.latency = le16_to_cpu(ev->interval) * 125 / 100;
 		bis->iso_qos.bcast.in.sdu = le16_to_cpu(ev->max_pdu);
 
+		hci_iso_setup_path(bis);
 		hci_connect_cfm(bis, ev->status);
 	}
 


### PR DESCRIPTION
This patch enables ISO data rx on broadcast sink.
Signed-off-by: Claudia Draghicescu <claudia.rosu@nxp.com>
---
 net/bluetooth/hci_event.c | 1 +
 1 file changed, 1 insertion(+)