### PR TITLE
[PW_SID:748779] [v2] Bluetooth: btnxpuart: Fix compiler warnings

### DIFF
--- a/drivers/bluetooth/btnxpuart.c
+++ b/drivers/bluetooth/btnxpuart.c
@@ -1319,6 +1319,7 @@ static void nxp_serdev_remove(struct serdev_device *serdev)
 	hci_free_dev(hdev);
 }
 
+#ifdef CONFIG_OF
 static struct btnxpuart_data w8987_data = {
 	.helper_fw_name = NULL,
 	.fw_name = FIRMWARE_W8987,
@@ -1335,6 +1336,7 @@ static const struct of_device_id nxpuart_of_match_table[] = {
 	{ }
 };
 MODULE_DEVICE_TABLE(of, nxpuart_of_match_table);
+#endif
 
 static struct serdev_device_driver nxp_serdev_driver = {
 	.probe = nxp_serdev_probe,


### PR DESCRIPTION
This fixes a compiler warning reported by kernel test robot.

Signed-off-by: Neeraj Sanjay Kale <neeraj.sanjaykale@nxp.com>
Reported-by: kernel test robot <lkp@intel.com>
Link: https://lore.kernel.org/oe-kbuild-all/202305161345.eClvTYQ9-lkp@intel.com/
---
 drivers/bluetooth/btnxpuart.c | 2 ++
 1 file changed, 2 insertions(+)