### PR TITLE
[PW_SID:760925] [v2] Bluetooth: btintel: Add support for Gale Peak

### DIFF
--- a/drivers/bluetooth/btintel.c
+++ b/drivers/bluetooth/btintel.c
@@ -480,6 +480,7 @@ static int btintel_version_info_tlv(struct hci_dev *hdev,
 	case 0x18:	/* Slr */
 	case 0x19:	/* Slr-F */
 	case 0x1b:      /* Mgr */
+	case 0x1c:	/* Gale Peak (GaP) */
 		break;
 	default:
 		bt_dev_err(hdev, "Unsupported Intel hardware variant (0x%x)",
@@ -2648,6 +2649,7 @@ static void btintel_set_msft_opcode(struct hci_dev *hdev, u8 hw_variant)
 	case 0x18:
 	case 0x19:
 	case 0x1b:
+	case 0x1c:
 		hci_set_msft_opcode(hdev, 0xFC1E);
 		break;
 	default:
@@ -2862,6 +2864,7 @@ static int btintel_setup_combined(struct hci_dev *hdev)
 	case 0x18:
 	case 0x19:
 	case 0x1b:
+	case 0x1c:
 		/* Display version information of TLV type */
 		btintel_version_info_tlv(hdev, &ver_tlv);
 


### PR DESCRIPTION
Add hardware variant(0x1c) for Gale Peak core (CNVi).

Signed-off-by: Kiran K <kiran.k@intel.com>
---
changes  in v2:
1. Expand GaP to Gale Peak
2. s/GalePeak/Gale Peak/g

 drivers/bluetooth/btintel.c | 3 +++
 1 file changed, 3 insertions(+)