### PR TITLE
[PW_SID:761864] Bluetooth: btmtk: fix handling of CONFIG_DEV_COREDUMP not being defined

### DIFF
--- a/drivers/bluetooth/btmtk.c
+++ b/drivers/bluetooth/btmtk.c
@@ -369,11 +369,9 @@ EXPORT_SYMBOL_GPL(btmtk_register_coredump);
 
 int btmtk_process_coredump(struct hci_dev *hdev, struct sk_buff *skb)
 {
+	int err = 0;
+#ifdef CONFIG_DEV_COREDUMP
 	struct btmediatek_data *data = hci_get_priv(hdev);
-	int err;
-
-	if (!IS_ENABLED(CONFIG_DEV_COREDUMP))
-		return 0;
 
 	switch (data->cd_info.state) {
 	case HCI_DEVCOREDUMP_IDLE:
@@ -407,7 +405,7 @@ int btmtk_process_coredump(struct hci_dev *hdev, struct sk_buff *skb)
 
 	if (err < 0)
 		kfree_skb(skb);
-
+#endif
 	return err;
 }
 EXPORT_SYMBOL_GPL(btmtk_process_coredump);


### PR DESCRIPTION
When CONFIG_DEV_COREDUMP is not defined, there is this error
drivers/bluetooth/btmtk.c: In function ‘btmtk_process_coredump’:
drivers/bluetooth/btmtk.c:386:44: error: ‘struct hci_dev’ has no member named ‘dump’
  386 |                 schedule_delayed_work(&hdev->dump.dump_timeout,
      |                                            ^~

The runtime IS_ENABLED(CONFIG_DEV_COREDUMP) is not enough to
prevent the compiletime error of accessing the dump element of hci_dev.
So switch to #ifdef.

Fixes: 872f8c253cb9 ("Bluetooth: btusb: mediatek: add MediaTek devcoredump support")
Signed-off-by: Tom Rix <trix@redhat.com>
---
 drivers/bluetooth/btmtk.c | 8 +++-----
 1 file changed, 3 insertions(+), 5 deletions(-)