### PR TITLE
[PW_SID:765155] [v6] Bluetooth: btmtk: Fix kernel crash when processing coredump

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          path: src/src
+
+      - name: CI
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: ci
+          base_folder: src
+          space: kernel
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,36 @@
+name: Snyc
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Sync Repo
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: sync
+          upstream_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sync Patchwork
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: patchwork
+          space: kernel
+          github_token: ${{ secrets.ACTION_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/drivers/bluetooth/btmtk.c
+++ b/drivers/bluetooth/btmtk.c
@@ -395,12 +395,12 @@ int btmtk_process_coredump(struct hci_dev *hdev, struct sk_buff *skb)
 
 		/* Mediatek coredump data would be more than MTK_COREDUMP_NUM */
 		if (data->cd_info.cnt > MTK_COREDUMP_NUM &&
-		    skb->len > sizeof(MTK_COREDUMP_END) &&
-		    !memcmp((char *)&skb->data[skb->len - sizeof(MTK_COREDUMP_END)],
-			    MTK_COREDUMP_END, sizeof(MTK_COREDUMP_END) - 1)) {
-			bt_dev_info(hdev, "Mediatek coredump end");
-			hci_devcd_complete(hdev);
-		}
+		    skb->len > MTK_COREDUMP_END_LEN)
+			if (!memcmp((char *)&skb->data[skb->len - MTK_COREDUMP_END_LEN],
+				    MTK_COREDUMP_END, MTK_COREDUMP_END_LEN - 1)) {
+				bt_dev_info(hdev, "Mediatek coredump end");
+				hci_devcd_complete(hdev);
+			}
 
 		break;
 	}

--- a/drivers/bluetooth/btmtk.h
+++ b/drivers/bluetooth/btmtk.h
@@ -24,6 +24,7 @@
 
 #define MTK_COREDUMP_SIZE		(1024 * 1000)
 #define MTK_COREDUMP_END		"coredump end"
+#define MTK_COREDUMP_END_LEN		(sizeof(MTK_COREDUMP_END))
 #define MTK_COREDUMP_NUM		255
 
 enum {


### PR DESCRIPTION
There may be a potential kernel crash risk if 'skb->len
- MTK_COREDUMP_END_LEN' value is less than 0 when doing
memcmp in btmtk_process_coredump().
Check the value is valid before doing memcmp.

[215.021695] Unable to handle kernel paging request at
             virtual address ffffff939fffd3c5
[215.021781] Mem abort info:
[215.021805]   ESR = 0x96000005
[215.021833]   EC = 0x25: DABT (current EL), IL = 32 bits
[215.021861]   SET = 0, FnV = 0
[215.021875]   EA = 0, S1PTW = 0
[215.021886] Data abort info:
[215.021899]   ISV = 0, ISS = 0x00000005
[215.021912]   CM = 0, WnR = 0
[215.021929] swapper pgtable: 4k pages, 39-bit VAs,
             pgdp=00000000410de000
[215.021943] [ffffff939fffd3c5] pgd=0000000000000000,
             p4d=0000000000000000, pud=0000000000000000
[215.021979] Internal error: Oops: 96000005 [#1] PREEMPT SMP
[215.022496] CPU: 0 PID: 0 Comm: swapper/0 Not tainted 5.10.186#3
             (HASH:ad23 4)
[215.022511] Hardware name: MediaTek Tomato board (DT)
[215.022530] pstate: 80400009 (Nzcv daif +PAN -UAO -TCO BTYPE=--)
[215.022556] pc : __pi_memcmp+0xd0/0x1b8
[215.022579] lr : btmtk_process_coredump+0xb0/0x5f8 [btmtk]
[215.022593] sp : ffffffc010003d40
[215.022607] x29: ffffffc010003d40 x28: 0000000000000006
[215.022633] x27: ffffffda696350c0 x26: 0000000000000002
[215.022659] x25: 00000000000003ff x24: ffffff9360cca804
[215.022685] x23: 0000000000000000 x22: ffffff9365638500
[215.022710] x21: ffffff9365638700 x20: 0000000000000000
[215.022736] x19: ffffff936002e000 x18: 0000000000000000
[215.022761] x17: 0000000000000180 x16: ffffffda6881b8b4
[215.022787] x15: 0000000000000001 x14: 0000000000002d00
[215.022812] x13: 0000000000060000 x12: 0000000000000181
[215.022837] x11: 0000000000000006 x10: fffffffffffffffd
[215.022862] x9 : 0000000000000006 x8 : 0000000000000003
[215.022887] x7 : 0000000000000000 x6 : 0000000000000000
[215.022913] x5 : ffffff93656387b8 x4 : 0000000000000000
[215.022938] x3 : ffffffc010003c18 x2 : 0000000000000006
[215.022963] x1 : ffffffda09d4124a x0 : ffffff939fffd3c5
[215.022989] Call trace:
[215.023012]  __pi_memcmp+0xd0/0x1b8
[215.023053]  btusb_recv_acl_mtk+0x64/0x90 [btusb (HASH:dc6b 5)]
[215.023087]  btusb_recv_bulk+0x118/0x170 [btusb (HASH:dc6b 5)]
[215.023121]  btusb_bulk_complete+0x8c/0x148 [btusb (HASH:dc6b 5)]
[215.023144]  __usb_hcd_giveback_urb+0xbc/0x148
[215.023164]  usb_giveback_urb_bh+0xb4/0x190
[215.023184]  tasklet_action_common+0x98/0x1a0
[215.023201]  tasklet_action+0x2c/0x38
[215.023220]  __do_softirq+0xe0/0x38c
[215.023241]  invoke_softirq+0x34/0x6c
[215.023258]  irq_exit+0x6c/0xb0
[215.023279]  __handle_domain_irq+0x98/0xd4
[215.023296]  gic_handle_irq+0x5c/0x11c
[215.023313]  el1_irq+0xd0/0x180
[215.023332]  cpuidle_enter_state+0xac/0x338
[215.023349]  cpuidle_enter+0x40/0x70
[215.023366]  do_idle+0x150/0x278
[215.023384]  cpu_startup_entry+0x2c/0x58
[215.023401]  rest_init+0xdc/0xec
[215.023419]  arch_call_rest_init+0x18/0x24
[215.023435]  start_kernel+0x334/0x400
[215.023460] Code: 91002129 eb09010a 9a89810b cb0b0042 (38401403)
[215.023478] ---[ end trace 28668fd20c7a90cd ]

Fixes: 2822cd0173ad ("Bluetooth: btusb: mediatek: add MediaTek devcoredump support")
Signed-off-by: Chris Lu <chris.lu@mediatek.com>
Co-developed-by: Sean Wang <sean.wang@mediatek.com>
Signed-off-by: Sean Wang <sean.wang@mediatek.com>
---
v1 -> v2: fix typo
v2 -> v3: fix bot checking error
v3 -> v4: reduce variable 'offset' declaration
v4 -> v5: update bug info in commit message
v5 -> v6: fix bot checking error
          commit message exceeds max length

 drivers/bluetooth/btmtk.c | 12 ++++++------
 drivers/bluetooth/btmtk.h |  1 +
 2 files changed, 7 insertions(+), 6 deletions(-)