### PR TITLE
[PW_SID:769739] [net-next] Bluetooth: Remove unused declaration amp_read_loc_info()

### DIFF
--- a/net/bluetooth/amp.h
+++ b/net/bluetooth/amp.h
@@ -28,7 +28,6 @@ struct hci_conn *phylink_add(struct hci_dev *hdev, struct amp_mgr *mgr,
 
 int phylink_gen_key(struct hci_conn *hcon, u8 *data, u8 *len, u8 *type);
 
-void amp_read_loc_info(struct hci_dev *hdev, struct amp_mgr *mgr);
 void amp_read_loc_assoc_frag(struct hci_dev *hdev, u8 phy_handle);
 void amp_read_loc_assoc(struct hci_dev *hdev, struct amp_mgr *mgr);
 void amp_read_loc_assoc_final_data(struct hci_dev *hdev,


### PR DESCRIPTION
This is never used, so remove it.

Signed-off-by: YueHaibing <yuehaibing@huawei.com>
---
 net/bluetooth/amp.h | 1 -
 1 file changed, 1 deletion(-)