### PR TITLE
[PW_SID:775278] Bluetooth: btnxpuart: Add support for IW624 chipset

### DIFF
--- a/drivers/bluetooth/btnxpuart.c
+++ b/drivers/bluetooth/btnxpuart.c
@@ -558,16 +558,11 @@ static int nxp_download_firmware(struct hci_dev *hdev)
 	}
 
 	serdev_device_set_flow_control(nxpdev->serdev, true);
-	err = serdev_device_wait_for_cts(nxpdev->serdev, 1, 60000);
-	if (err < 0) {
-		bt_dev_err(hdev, "CTS is still high. FW Download failed.");
-		return err;
-	}
 	release_firmware(nxpdev->fw);
 	memset(nxpdev->fw_name, 0, sizeof(nxpdev->fw_name));
 
 	/* Allow the downloaded FW to initialize */
-	usleep_range(800 * USEC_PER_MSEC, 1 * USEC_PER_SEC);
+	msleep(1200);
 
 	return 0;
 }


### PR DESCRIPTION
This removes the unnecessary check for CTS low after FW download.

After FW download is complete, the CTS line is already seen low.
It becomes high after 2 msec, and low again after FW initialization
is complete.
This makes the current check for CTS low redundant.

This removes the wait for CTS low section and increase delay to
1200msec instead, which is sufficiant for all NXP chipsets to
initialize FW.

Signed-off-by: Neeraj Sanjay Kale <neeraj.sanjaykale@nxp.com>
---
v2: Remove wait_for_cts low check in a separate commit (Francesco
Dolcini)
---
 drivers/bluetooth/btnxpuart.c | 7 +------
 1 file changed, 1 insertion(+), 6 deletions(-)