### PR TITLE
[PW_SID:783271] [v3,1/1] Bluetooth: ISO: Set CIS bit only for devices with CIS support

### DIFF
--- a/net/bluetooth/hci_sync.c
+++ b/net/bluetooth/hci_sync.c
@@ -4264,12 +4264,12 @@ static int hci_le_set_host_feature_sync(struct hci_dev *hdev)
 {
 	struct hci_cp_le_set_host_feature cp;
 
-	if (!iso_capable(hdev))
+	if (!cis_capable(hdev))
 		return 0;
 
 	memset(&cp, 0, sizeof(cp));
 
-	/* Isochronous Channels (Host Support) */
+	/* Connected Isochronous Channels (Host Support) */
 	cp.bit_number = 32;
 	cp.bit_value = 1;
 


### PR DESCRIPTION
As mentioned in the Bluetooth Specification the full name of this bit is
"Connected Isochronous Stream (Host Support)", thus it should be set only
for CIS capable devices. Currently, it is set for any device that has CIS
or BIS support. In reality, devices that support BIS may not allow that 
bit to be set and so, the HCI bring up fails for them.

This commit fixes this by only setting the bit for CIS capable devices.

Signed-off-by: Vlad Pruteanu <vlad.pruteanu@nxp.com>
---
 net/bluetooth/hci_sync.c | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)