### PR TITLE
[PW_SID:798561] [v2,1/1] Bluetooth: hci_event: Correct power save marking logic

### DIFF
--- a/net/bluetooth/hci_event.c
+++ b/net/bluetooth/hci_event.c
@@ -4590,9 +4590,9 @@ static void hci_mode_change_evt(struct hci_dev *hdev, void *data,
 		if (!test_and_clear_bit(HCI_CONN_MODE_CHANGE_PEND,
 					&conn->flags)) {
 			if (conn->mode == HCI_CM_ACTIVE)
-				set_bit(HCI_CONN_POWER_SAVE, &conn->flags);
-			else
 				clear_bit(HCI_CONN_POWER_SAVE, &conn->flags);
+			else
+				set_bit(HCI_CONN_POWER_SAVE, &conn->flags);
 		}
 
 		if (test_and_clear_bit(HCI_CONN_SCO_SETUP_PEND, &conn->flags))


### PR DESCRIPTION
HCI_CONN_POWER_SAVE should stand for non active mode, but
hci_mode_change_evt() wrongly set this flag, it is corrected
by this change.

Signed-off-by: Zijun Hu <quic_zijuhu@quicinc.com>
---
 net/bluetooth/hci_event.c | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)