### PR TITLE
[PW_SID:814542] Bluetooth: mgmt: Fix wrong param be used

### DIFF
--- a/net/bluetooth/mgmt.c
+++ b/net/bluetooth/mgmt.c
@@ -5177,7 +5177,7 @@ unlock:
 
 done:
 	if (status == MGMT_STATUS_SUCCESS)
-		device_flags_changed(sk, hdev, &cp->addr.bdaddr, cp->addr.type,
+		device_flags_changed(NULL, hdev, &cp->addr.bdaddr, cp->addr.type,
 				     supported_flags, current_flags);
 
 	return mgmt_cmd_complete(sk, hdev->id, MGMT_OP_SET_DEVICE_FLAGS, status,


### PR DESCRIPTION
From: Clancy Shang <clancy.shang@quectel.com>

bluez lib could not receive MGMT_EV_DEVICE_FLAGS_CHANGED notifications
after sending MGMT_OP_SET_DEVICE_FLAGS

Signed-off-by: Clancy Shang <clancy.shang@quectel.com>
---
 net/bluetooth/mgmt.c | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)