### PR TITLE
[PW_SID:839335] Bluetooth: btintel: Add devices to HCI_QUIRK_BROKEN_LE_CODED

### DIFF
--- a/drivers/bluetooth/btintel.c
+++ b/drivers/bluetooth/btintel.c
@@ -3030,6 +3030,8 @@ static int btintel_setup_combined(struct hci_dev *hdev)
 	case 0x17:
 	case 0x18:
 	case 0x19:
+		/* 0x17, 0x18 and 0x19 have issues when LE Coded PHY is enabled */
+		set_bit(HCI_QUIRK_BROKEN_LE_CODED, &hdev->quirks);
 	case 0x1b:
 	case 0x1c:
 		/* Display version information of TLV type */


### PR DESCRIPTION
From: Christoffer Sandberg <cs@tuxedo.de>

For HW variants 0x17, 0x18 and 0x19 LE Coded PHY causes scan and
connection issues when enabled. This patch disables it through
the existing quirk.

Signed-off-by: Christoffer Sandberg <cs@tuxedo.de>
Signed-off-by: Werner Sembach <wse@tuxedocomputers.com>
Cc: <stable@vger.kernel.org>
---
 drivers/bluetooth/btintel.c | 2 ++
 1 file changed, 2 insertions(+)