### PR TITLE
[PW_SID:849964] [v2] Bluetooth: HCI: Fix potential null-ptr-deref

### DIFF
--- a/net/bluetooth/hci_event.c
+++ b/net/bluetooth/hci_event.c
@@ -7069,6 +7069,8 @@ static void hci_le_big_sync_established_evt(struct hci_dev *hdev, void *data,
 			u16 handle = le16_to_cpu(ev->bis[i]);
 
 			bis = hci_conn_hash_lookup_handle(hdev, handle);
+			if (!bis)
+				continue;
 
 			set_bit(HCI_CONN_BIG_SYNC_FAILED, &bis->flags);
 			hci_connect_cfm(bis, ev->status);


### PR DESCRIPTION
Fix potential null-ptr-deref in hci_le_big_sync_established_evt().

Fixes: f777d8827817 (Bluetooth: ISO: Notify user space about failed bis connections)
Signed-off-by: Sungwoo Kim <iam@sung-woo.kim>
---
v1 -> v2:
- add a Fixes tag
- make the commit message concise

 net/bluetooth/hci_event.c | 2 ++
 1 file changed, 2 insertions(+)