### PR TITLE
[PW_SID:860197] Bluetooth: fix connection setup in l2cap_connect

### DIFF
--- a/net/bluetooth/l2cap_core.c
+++ b/net/bluetooth/l2cap_core.c
@@ -4016,8 +4016,8 @@ static void l2cap_connect(struct l2cap_conn *conn, struct l2cap_cmd_hdr *cmd,
 				status = L2CAP_CS_NO_INFO;
 			}
 		} else {
-			l2cap_state_change(chan, BT_CONNECT2);
-			result = L2CAP_CR_PEND;
+			l2cap_state_change(chan, BT_CONFIG);
+			result = L2CAP_CR_SUCCESS;
 			status = L2CAP_CS_AUTHEN_PEND;
 		}
 	} else {


### PR DESCRIPTION
The amp_id argument of l2cap_connect() was removed in
commit 84a4bb6548a2 ("Bluetooth: HCI: Remove HCI_AMP support")

It was always called with amp_id == 0, i.e. AMP_ID_BREDR == 0x00 (ie.
non-AMP controller).  In the above commit, the code path for amp_id != 0
was preserved, although it should have used the amp_id == 0 one.

Restore the previous behavior of the non-AMP code path, to fix problems
with L2CAP connections.

Fixes: 84a4bb6548a2 ("Bluetooth: HCI: Remove HCI_AMP support")
Signed-off-by: Pauli Virtanen <pav@iki.fi>
---

Notes:
    Tried proofreading the commit, and this part seemed suspicious.
    Can you try if this fixes the problem?

 net/bluetooth/l2cap_core.c | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)