### PR TITLE
[PW_SID:863363] [v1] Bluetooth: btintel: Add firmware ID to firmware name

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          path: src/src
+
+      - name: CI
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: ci
+          base_folder: src
+          space: kernel
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,36 @@
+name: Snyc
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Sync Repo
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: sync
+          upstream_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sync Patchwork
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: patchwork
+          space: kernel
+          github_token: ${{ secrets.ACTION_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/drivers/bluetooth/btintel.h
+++ b/drivers/bluetooth/btintel.h
@@ -42,7 +42,8 @@ enum {
 	INTEL_TLV_SBE_TYPE,
 	INTEL_TLV_OTP_BDADDR,
 	INTEL_TLV_UNLOCKED_STATE,
-	INTEL_TLV_GIT_SHA1
+	INTEL_TLV_GIT_SHA1,
+	INTEL_TLV_FW_ID = 0x50
 };
 
 struct intel_tlv {
@@ -56,6 +57,8 @@ struct intel_tlv {
 #define BTINTEL_IMG_BOOTLOADER		0x01	/* Bootloader image */
 #define BTINTEL_IMG_IML			0x02	/* Intermediate image */
 #define BTINTEL_IMG_OP			0x03	/* Operational image */
+
+#define BTINTEL_FWID_MAXLEN 64
 
 struct intel_version_tlv {
 	u32	cnvi_top;
@@ -77,6 +80,7 @@ struct intel_version_tlv {
 	u8	limited_cce;
 	u8	sbe_type;
 	u32	git_sha1;
+	u8	fw_id[BTINTEL_FWID_MAXLEN];
 	bdaddr_t otp_bd_addr;
 };
 


### PR DESCRIPTION
From BlazarI onwards, driver shall append the firmware ID (usually
represents transport type) while constructing the firmware name.
Firmware ID is returned on Intel Read Version command.

The new firmware file name for operational image and ddc file shall be,
ibt-<cnvi_top type+cnvi_top step>-<cnvr_top type+cnvr_top step-fw_id>.[sfi|ddc]

dmesg snippet from BlazarI pcie  product:

......

[17.098858] Bluetooth: hci0: Found device firmware: intel/ibt-0190-0291-pci.sfi
[17.098871] Bluetooth: hci0: Boot Address: 0x10000800
[17.098872] Bluetooth: hci0: Firmware Version: 214-25.24
[17.158229] Bluetooth: BNEP (Ethernet Emulation) ver 1.3
[17.158236] Bluetooth: BNEP filters: protocol multicast
[17.158241] Bluetooth: BNEP socket layer initialized
[17.468789] Bluetooth: hci0: Waiting for firmware download to complete
[17.468793] Bluetooth: hci0: Firmware loaded in 361262 usecs
[17.468872] Bluetooth: hci0: Waiting for device to boot
[17.504148] Bluetooth: hci0: Device booted in 34512 usecs
[17.504148] Bluetooth: hci0: Malformed MSFT vendor event: 0x02
[17.504682] Bluetooth: hci0: Found Intel DDC parameters: intel/ibt-0190-0291-pci.ddc
[17.505380] Bluetooth: hci0: Applying Intel DDC parameters completed
[17.505622] Bluetooth: hci0: Firmware timestamp 2024.25 buildtype 3 build 64726
[17.505624] Bluetooth: hci0: Firmware SHA1: 0x9f4adddc
[17.505838] Bluetooth: hci0: Fseq status: Success (0x00)
[17.505839] Bluetooth: hci0: Fseq executed: 00.00.04.183
[17.505840] Bluetooth: hci0: Fseq BT Top: 00.00.04.183

dmesg snippet from BlazarI usb product:

.......

[14.212072] Bluetooth: hci0: Found device firmware: intel/ibt-0190-0291-usb.sfi
[14.212091] Bluetooth: hci0: Boot Address: 0x10000800
[14.212093] Bluetooth: hci0: Firmware Version: 79-21.24
[14.262125] Bluetooth: BNEP (Ethernet Emulation) ver 1.3
[14.262129] Bluetooth: BNEP filters: protocol multicast
[14.262133] Bluetooth: BNEP socket layer initialized
[15.865421] Bluetooth: hci0: Waiting for firmware download to complete
[15.865991] Bluetooth: hci0: Firmware loaded in 1615150 usecs
[15.866017] Bluetooth: hci0: Waiting for device to boot
[15.899934] Bluetooth: hci0: Malformed MSFT vendor event: 0x02
[15.899942] Bluetooth: hci0: Device booted in 33139 usecs
[15.900172] Bluetooth: hci0: Found Intel DDC parameters: intel/ibt-0190-0291-usb.ddc
[15.901928] Bluetooth: hci0: Applying Intel DDC parameters completed
[15.904993] Bluetooth: hci0: Firmware timestamp 2024.21 buildtype 3 build 63311
[15.904996] Bluetooth: hci0: Firmware SHA1: 0x8b217cf7
[15.908929] Bluetooth: hci0: Fseq status: Success (0x00)
[15.908934] Bluetooth: hci0: Fseq executed: 00.00.04.180
[15.908935] Bluetooth: hci0: Fseq BT Top: 00.00.04.180

Signed-off-by: Kiran K <kiran.k@intel.com>
---
 drivers/bluetooth/btintel.c | 88 ++++++++++++++++++++++++++++---------
 drivers/bluetooth/btintel.h |  6 ++-
 2 files changed, 73 insertions(+), 21 deletions(-)