### PR TITLE
[PW_SID:866149] [v1] Bluetooth: btintel: Fix the sfi name for BlazarU

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          path: src/src
+
+      - name: CI
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: ci
+          base_folder: src
+          space: kernel
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,36 @@
+name: Snyc
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Sync Repo
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: sync
+          upstream_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sync Patchwork
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: patchwork
+          space: kernel
+          github_token: ${{ secrets.ACTION_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/drivers/bluetooth/btintel.c
+++ b/drivers/bluetooth/btintel.c
@@ -2148,7 +2148,7 @@ static void btintel_get_fw_name_tlv(const struct intel_version_tlv *ver,
 	/* Only Blazar  product supports downloading of intermediate loader
 	 * image
 	 */
-	if ((ver->cnvi_top & 0xfff) >= BTINTEL_CNVI_BLAZARI) {
+	if (INTEL_HW_VARIANT(ver->cnvi_bt) >= 0x1e) {
 		u8 zero[BTINTEL_FWID_MAXLEN];
 
 		if (ver->img_type == BTINTEL_IMG_BOOTLOADER) {
@@ -2240,7 +2240,7 @@ static int btintel_prepare_fw_download_tlv(struct hci_dev *hdev,
 		 * firmware image which doesn't exist. Lets compare the version
 		 * of IML image
 		 */
-		if ((ver->cnvi_top & 0xfff) >= BTINTEL_CNVI_BLAZARI)
+		if (INTEL_HW_VARIANT(ver->cnvi_bt) >= 0x1e)
 			btintel_get_iml_tlv(ver, fwname, sizeof(fwname), "sfi");
 		else
 			btintel_get_fw_name_tlv(ver, fwname, sizeof(fwname), "sfi");


### PR DESCRIPTION
Use INTEL_HW_VARIANT() instead of CNVi Id to decide to load Intermediate
Loader (IML) image. Fix the driver loading incorrect firmware for
BlazarU product.

dmesg:
.....
[146.111834] Bluetooth: hci0: Minimum firmware build 1 week 10 2014
[146.111839] Bluetooth: hci0: Bootloader timestamp 2022.18 buildtype 1 build 16362
[146.111848] Bluetooth: hci0: No support for _PRR ACPI method
[146.112204] Bluetooth: hci0: Failed to load Intel firmware file intel/ibt-0291-0291-iml.sfi (-2)

Fixes: a5495fe62d9f ("Bluetooth: btintel: Add firmware ID to firmware name")
Reported-by: Tsigan, Vladislav <vladislav.tsigan@intel.com>
Signed-off-by: Kiran K <kiran.k@intel.com>
---
 drivers/bluetooth/btintel.c | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)