### PR TITLE
[PW_SID:870300] [v1] Bluetooth: hci_qca: Fix build error

### DIFF
--- a/drivers/bluetooth/hci_qca.c
+++ b/drivers/bluetooth/hci_qca.c
@@ -2498,7 +2498,6 @@ static void qca_serdev_remove(struct serdev_device *serdev)
 		if (power->vregs_on)
 			qca_power_shutdown(&qcadev->serdev_hu);
 		break;
-	default:
 	}
 
 	hci_uart_unregister_device(&qcadev->serdev_hu);


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This fixes the following build error introduced by a887c8dede8e
("Bluetooth: hci_qca: schedule a devm action for disabling the clock"):

drivers/bluetooth/hci_qca.c: In function ‘qca_serdev_remove’:
drivers/bluetooth/hci_qca.c:2501:2: error: label at end of compound statement
 2501 |  default:
      |  ^~~~~~~

Fixes: a887c8dede8e ("Bluetooth: hci_qca: schedule a devm action for disabling the clock")
Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
---
 drivers/bluetooth/hci_qca.c | 1 -
 1 file changed, 1 deletion(-)