### PR TITLE
[PW_SID:890889] Bluetooth: btbcm: Handle memory allocation failure in btbcm_get_board_name()

### DIFF
--- a/drivers/bluetooth/btbcm.c
+++ b/drivers/bluetooth/btbcm.c
@@ -554,6 +554,8 @@ static const char *btbcm_get_board_name(struct device *dev)
 
 	/* get rid of any '/' in the compatible string */
 	board_type = devm_kstrdup(dev, tmp, GFP_KERNEL);
+	if (!board_type)
+		return NULL;
 	strreplace(board_type, '/', '-');
 	of_node_put(root);
 


### PR DESCRIPTION
In btbcm_get_board_name() devm_kstrdup() can return NULL due to memory
allocation failure.

Add NULL return check to prevent NULL dereference.

Found by Linux Verification Center (linuxtesting.org) with SVACE.

Fixes: 63fac3343b99 ("Bluetooth: btbcm: Support per-board firmware variants")
Signed-off-by: Aleksandr Mishin <amishin@t-argos.ru>
---
 drivers/bluetooth/btbcm.c | 2 ++
 1 file changed, 2 insertions(+)