### PR TITLE
[PW_SID:898991] [next] Bluetooth: btintel_pcie: Remove structually deadcode

### DIFF
--- a/drivers/bluetooth/btintel_pcie.c
+++ b/drivers/bluetooth/btintel_pcie.c
@@ -391,7 +391,6 @@ static inline char *btintel_pcie_alivectxt_state2str(u32 alive_intr_ctxt)
 	default:
 		return "unknown";
 	}
-	return "null";
 }
 
 /* This function handles the MSI-X interrupt for gp0 cause (bit 0 in


### PR DESCRIPTION
The switch case statement has a default branch. Thus, the return
statement at the end of the function can never be reached.
Fixing it by removing the return statement at the end of the
function.

This issue was reported by Coverity Scan.
https://scan7.scan.coverity.com/#/project-view/51525/11354?selectedIssue=1600709

Fixes: 5ea625845b0f ("Bluetooth: btintel_pcie: Add handshake between driver and firmware")
Signed-off-by: Everest K.C. <everestkc@everestkc.com.np>
---
 drivers/bluetooth/btintel_pcie.c | 1 -
 1 file changed, 1 deletion(-)