### PR TITLE
[PW_SID:902204] [v1] Bluetooth: btmtk: adjust the position to init iso data anchor

### DIFF
--- a/drivers/bluetooth/btmtk.c
+++ b/drivers/bluetooth/btmtk.c
@@ -1215,7 +1215,6 @@ static int btmtk_usb_isointf_init(struct hci_dev *hdev)
 	struct sk_buff *skb;
 	int err;
 
-	init_usb_anchor(&btmtk_data->isopkt_anchor);
 	spin_lock_init(&btmtk_data->isorxlock);
 
 	__set_mtk_intr_interface(hdev);

--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -2628,6 +2628,8 @@ static void btusb_mtk_claim_iso_intf(struct btusb_data *data)
 	struct btmtk_data *btmtk_data = hci_get_priv(data->hdev);
 	int err;
 
+	init_usb_anchor(&btmtk_data->isopkt_anchor);
+
 	err = usb_driver_claim_interface(&btusb_driver,
 					 btmtk_data->isopkt_intf, data);
 	if (err < 0) {


### PR DESCRIPTION
MediaTek iso data anchor init should be move to where MediaTek
claims iso data interface.
If there is an unexpected usb disconnect during setup flow,
it will cause a NULL pointer crash issue when releasing iso
anchor since the anchor wan't been init yet. Adjust the position
to do iso data anchor init.

Signed-off-by: Chris Lu <chris.lu@mediatek.com>
---
 drivers/bluetooth/btmtk.c | 1 -
 drivers/bluetooth/btusb.c | 2 ++
 2 files changed, 2 insertions(+), 1 deletion(-)