### PR TITLE
[PW_SID:910294] [v2] Bluetooth: qca: Support downloading board ID specific NVM for WCN6855

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          path: src/src
+
+      - name: CI
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: ci
+          base_folder: src
+          space: kernel
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,36 @@
+name: Snyc
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Sync Repo
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: sync
+          upstream_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sync Patchwork
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: patchwork
+          space: kernel
+          github_token: ${{ secrets.ACTION_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/drivers/bluetooth/btqca.c
+++ b/drivers/bluetooth/btqca.c
@@ -717,6 +717,29 @@ static void qca_generate_hsp_nvm_name(char *fwname, size_t max_size,
 		snprintf(fwname, max_size, "qca/hpnv%02x%s.%x", rom_ver, variant, bid);
 }
 
+static void qca_get_hsp_nvm_name_generic(struct qca_fw_config *cfg,
+					 struct qca_btsoc_version ver,
+					 u8 rom_ver, u16 bid)
+{
+	const char *variant;
+
+	/* hsp gf chip */
+	if ((le32_to_cpu(ver.soc_id) & QCA_HSP_GF_SOC_MASK) == QCA_HSP_GF_SOC_ID)
+		variant = "g";
+	else
+		variant = "";
+
+	if (bid == 0x0)
+		snprintf(cfg->fwname, sizeof(cfg->fwname), "qca/hpnv%02x%s.bin",
+			 rom_ver, variant);
+	else if (bid & 0xff00)
+		snprintf(cfg->fwname, sizeof(cfg->fwname), "qca/hpnv%02x%s.b%x",
+			 rom_ver, variant, bid);
+	else
+		snprintf(cfg->fwname, sizeof(cfg->fwname), "qca/hpnv%02x%s.b%02x",
+			 rom_ver, variant, bid);
+}
+
 static inline void qca_get_nvm_name_generic(struct qca_fw_config *cfg,
 					    const char *stem, u8 rom_ver, u16 bid)
 {
@@ -810,8 +833,15 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
 	/* Give the controller some time to get ready to receive the NVM */
 	msleep(10);
 
-	if (soc_type == QCA_QCA2066 || soc_type == QCA_WCN7850)
+	switch (soc_type) {
+	case QCA_QCA2066:
+	case QCA_WCN6855:
+	case QCA_WCN7850:
 		qca_read_fw_board_id(hdev, &boardid);
+		break;
+	default:
+		break;
+	}
 
 	/* Download NVM configuration */
 	config.type = TLV_TYPE_NVM;
@@ -848,8 +878,7 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
 				 "qca/msnv%02x.bin", rom_ver);
 			break;
 		case QCA_WCN6855:
-			snprintf(config.fwname, sizeof(config.fwname),
-				 "qca/hpnv%02x.bin", rom_ver);
+			qca_get_hsp_nvm_name_generic(&config, ver, rom_ver, boardid);
 			break;
 		case QCA_WCN7850:
 			qca_get_nvm_name_generic(&config, "hmt", rom_ver, boardid);
@@ -861,9 +890,18 @@ int qca_uart_setup(struct hci_dev *hdev, uint8_t baudrate,
 		}
 	}
 
+download_nvm:
 	err = qca_download_firmware(hdev, &config, soc_type, rom_ver);
 	if (err < 0) {
 		bt_dev_err(hdev, "QCA Failed to download NVM (%d)", err);
+		if (err == -ENOENT && boardid != 0 &&
+		    soc_type == QCA_WCN6855) {
+			boardid = 0;
+			qca_get_hsp_nvm_name_generic(&config, ver,
+						     rom_ver, boardid);
+			bt_dev_warn(hdev, "QCA fallback to default NVM");
+			goto download_nvm;
+		}
 		return err;
 	}
 


### PR DESCRIPTION
For WCN6855, board ID specific NVM needs to be downloaded once board ID
is available, but the default NVM is always downloaded currently, and
the wrong NVM causes poor RF performance which effects user experience.

Fix by downloading board ID specific NVM if board ID is available.

Cc: Bjorn Andersson <bjorande@quicinc.com>
Cc: Aiqun Yu (Maria) <quic_aiquny@quicinc.com>
Cc: Cheng Jiang <quic_chejiang@quicinc.com>
Cc: Johan Hovold <johan@kernel.org>
Cc: Jens Glathe <jens.glathe@oldschoolsolutions.biz>
Cc: Steev Klimaszewski <steev@kali.org>
Cc: Paul Menzel <pmenzel@molgen.mpg.de>
Fixes: 095327fede00 ("Bluetooth: hci_qca: Add support for QTI Bluetooth chip wcn6855")
Cc: stable@vger.kernel.org # 6.4
Reviewed-by: Johan Hovold <johan+linaro@kernel.org>
Tested-by: Johan Hovold <johan+linaro@kernel.org>
Tested-by: Steev Klimaszewski <steev@kali.org>
Tested-by: Jens Glathe <jens.glathe@oldschoolsolutions.biz>
Signed-off-by: Zijun Hu <quic_zijuhu@quicinc.com>
---
Thank you Paul, Jens, Steev, Johan, Luiz for code review, various
verification, comments and suggestions. these comments and suggestions
are very good, and all of them are taken by this v2 patch.

Regarding the variant 'g', sorry for that i can say nothing due to
confidential information (CCI), but fortunately, we don't need to
care about its difference against one without 'g' from BT host
perspective, qca_get_hsp_nvm_name_generic() shows how to map BT chip
to firmware.

I will help to backport it to LTS kernels ASAP once this commit
is mainlined.
---
Changes in v2:
- Correct subject and commit message
- Temporarily add nvm fallback logic to speed up backport.
— Add fix/stable tags as suggested by Luiz and Johan
- Link to v1: https://lore.kernel.org/r/20241113-x13s_wcn6855_fix-v1-1-15af0aa2549c@quicinc.com
---
 drivers/bluetooth/btqca.c | 44 +++++++++++++++++++++++++++++++++++++++++---
 1 file changed, 41 insertions(+), 3 deletions(-)


---
base-commit: e88b020190bf5bc3e7ce5bd8003fc39b23cc95fe
change-id: 20241113-x13s_wcn6855_fix-53c573ff7878

Best regards,