### PR TITLE
[PW_SID:910549] [v2] bluetooth: add quirk using packet size 60

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          path: src/src
+
+      - name: CI
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: ci
+          base_folder: src
+          space: kernel
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,36 @@
+name: Snyc
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Sync Repo
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: sync
+          upstream_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sync Patchwork
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: patchwork
+          space: kernel
+          github_token: ${{ secrets.ACTION_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/drivers/bluetooth/btrtl.c
+++ b/drivers/bluetooth/btrtl.c
@@ -1312,6 +1312,9 @@ void btrtl_set_quirks(struct hci_dev *hdev, struct btrtl_device_info *btrtl_dev)
 		    btrtl_dev->project_id == CHIP_ID_8852C)
 			set_bit(HCI_QUIRK_USE_MSFT_EXT_ADDRESS_FILTER, &hdev->quirks);
 
+		if (btrtl_dev->project_id == CHIP_ID_8852BT)
+			btrealtek_set_flag(hdev, REALTEK_ALT6_FORCE);
+
 		hci_set_aosp_capable(hdev);
 		break;
 	default:

--- a/drivers/bluetooth/btrtl.h
+++ b/drivers/bluetooth/btrtl.h
@@ -105,6 +105,7 @@ struct rtl_vendor_cmd {
 
 enum {
 	REALTEK_ALT6_CONTINUOUS_TX_CHIP,
+	REALTEK_ALT6_FORCE,
 
 	__REALTEK_NUM_FLAGS,
 };


### PR DESCRIPTION
The RTL8852BE-VT supports USB alternate setting 6.
However, its descriptor does not report this capability to the host.
Therefore, a quirk is needed to bypass the RTL8852BE-VT's descriptor
and allow it to use USB ALT 6 directly.

The btmon log below shows the case that WBS with the USB alternate
setting 6.

> ACL Data RX: Handle 2 flags 0x02 dlen 18       #5338 [hci0] 91.977373
      Channel: 70 len 14 [PSM 3 mode Basic (0x00)] {chan 3}
      RFCOMM: Unnumbered Info with Header Check (UIH) (0xef)
         Address: 0x09 cr 0 dlci 0x02
         Control: 0xff poll/final 1
         Length: 9
         FCS: 0x5c
         Credits: 4
        41 54 2b 42 43 53 3d 32 0d 5c                    AT+BCS=2.\    >
< ACL Data TX: Handle 2 flags 0x00 dlen 15       #5339 [hci0] 91.978294
      Channel: 64 len 11 [PSM 3 mode Basic (0x00)] {chan 3}
      RFCOMM: Unnumbered Info with Header Check (UIH) (0xef)
         Address: 0x0b cr 1 dlci 0x02
         Control: 0xff poll/final 1
         Length: 6
         FCS: 0x86
         Credits: 1
        0d 0a 4f 4b 0d 0a 86                             ..OK...       >
< HCI Command: Enhanced.. (0x01|0x003d) plen 59  #5340 [hci0] 91.978326
        Handle: 2
        Transmit bandwidth: 8000
        Receive bandwidth: 8000
        Max latency: 13
        Packet type: 0x0380
          3-EV3 may not be used
          2-EV5 may not be used
          3-EV5 may not be used
        Retransmission effort: Optimize for link quality (0x02)
> HCI Event: Command Status (0x0f) plen 4        #5341 [hci0] 91.981723
      Enhanced Setup Synchronous Connection (0x01|0x003d) ncmd 2
        Status: Success (0x00)
> HCI Event: Number of Complete.. (0x13) plen 5  #5342 [hci0] 91.982705
        Num handles: 1
        Handle: 2
        Count: 1
> HCI Event: Synchronous Conne.. (0x2c) plen 17  #5343 [hci0] 92.015758
        Status: Success (0x00)
        Handle: 3
        Address: 78:A7:EB:4C:53:4D (OUI 78-A7-EB)
        Link type: eSCO (0x02)
        Transmission interval: 0x0c
        Retransmission window: 0x04
        RX packet length: 60
        TX packet length: 60
        Air mode: Transparent (0x03)
@ MGMT Open: bt_main_th.. (privileged) version 1.22  {0x0003} 92.016366
@ MGMT Command: Unknown (0x0101) plen 11             {0x0003} 92.016374
        00 00 78 a7 eb 4c 53 4d 00 01 02                 ..x..LSM...   >
@ MGMT Close: bt_main_thread                         {0x0003} 92.016409
< ACL Data TX: Handle 2 flags 0x00 dlen 22       #5344 [hci0] 92.017651
      Channel: 64 len 18 [PSM 3 mode Basic (0x00)] {chan 3}
      RFCOMM: Unnumbered Info with Header Check (UIH) (0xef)
         Address: 0x0b cr 1 dlci 0x02
         Control: 0xef poll/final 0
         Length: 14
         FCS: 0x9a
        0d 0a 2b 43 49 45 56 3a 20 32 2c 32 0d 0a 9a     ..+CIEV: 2,2..>
...
> SCO Data RX: Handle 3 flags 0x00 dlen 60       #5349 [hci0] 92.037778
< SCO Data TX: Handle 3 flags 0x00 dlen 60       #5350 [hci0] 92.038218
> HCI Event: Max Slots Change (0x1b) plen 3      #5351 [hci0] 92.040758
        Handle: 2
        Max slots: 1
> HCI Event: Number of Complete.. (0x13) plen 5  #5352 [hci0] 92.041760
        Num handles: 1
        Handle: 2
        Count: 1
> HCI Event: Number of Complete.. (0x13) plen 5  #5353 [hci0] 92.044784
        Num handles: 1
        Handle: 2
        Count: 1
> SCO Data RX: Handle 3 flags 0x00 dlen 60       #5354 [hci0] 92.047706
< SCO Data TX: Handle 3 flags 0x00 dlen 60       #5355 [hci0] 92.048226
> SCO Data RX: Handle 3 flags 0x00 dlen 60       #5356 [hci0] 92.057706
< SCO Data TX: Handle 3 flags 0x00 dlen 60       #5357 [hci0] 92.058179
...
> SCO Data RX: Handle 3 flags 0x00 dlen 60       #5362 [hci0] 92.067775
> SCO Data RX: Handle 3 flags 0x00 dlen 60       #5363 [hci0] 92.067780
< SCO Data TX: Handle 3 flags 0x00 dlen 60       #5364 [hci0] 92.068288
< SCO Data TX: Handle 3 flags 0x00 dlen 60       #5365 [hci0] 92.068322
> SCO Data RX: Handle 3 flags 0x00 dlen 60       #5366 [hci0] 92.077733
< SCO Data TX: Handle 3 flags 0x00 dlen 60       #5367 [hci0] 92.078263

Signed-off-by: Alex Lu <alex_lu@realsil.com.cn>
Signed-off-by: Hilda Wu <hildawu@realtek.com>

---
Change:
v2: Use btusb_find_altsetting replace duplicating logic, add tested log.
---
---
 drivers/bluetooth/btrtl.c |  3 ++
 drivers/bluetooth/btrtl.h |  1 +
 drivers/bluetooth/btusb.c | 82 +++++++++++++++++++++++++++++----------
 3 files changed, 66 insertions(+), 20 deletions(-)