### PR TITLE
[PW_SID:910673] Bluetooth: hci_sync: fix LE init stage 3 failure

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          path: src/src
+
+      - name: CI
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: ci
+          base_folder: src
+          space: kernel
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,36 @@
+name: Snyc
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Sync Repo
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: sync
+          upstream_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sync Patchwork
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: patchwork
+          space: kernel
+          github_token: ${{ secrets.ACTION_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/net/bluetooth/hci_sync.c
+++ b/net/bluetooth/hci_sync.c
@@ -4416,6 +4416,15 @@ static int hci_le_read_num_support_adv_sets_sync(struct hci_dev *hdev)
 	if (!ext_adv_capable(hdev))
 		return 0;
 
+	/* Checking for extended advertising capabilities is not enough; refine
+	 * by checking if the HCI_LE_Read_Number_of_Supported_Advertising_Sets
+	 * command is supported. Since this command is part of the LE init
+	 * stage 3, the initialization will fail whenever the command is not
+	 * supported for devices that indicate extended advertising features.
+	 */
+	if (!(hdev->commands[36] & 0x80))
+		return 0;
+
 	return __hci_cmd_sync_status(hdev,
 				     HCI_OP_LE_READ_NUM_SUPPORTED_ADV_SETS,
 				     0, NULL, HCI_CMD_TIMEOUT);


### PR DESCRIPTION
A controller may indicate support for the extended advertising feature but
doesn't support the HCI_LE_Read_Number_of_Supported_Advertising_Sets
command, which will cause the initialization to fail.

Signed-off-by: André Groenewald <andre.groenewald@streamunlimited.com>
---
 net/bluetooth/hci_sync.c | 9 +++++++++
 1 file changed, 9 insertions(+)