### PR TITLE
[PW_SID:911980] Bluetooth: btusb: Ignore Nintendo Wii module

### DIFF
--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -182,7 +182,10 @@ static const struct usb_device_id quirks_table[] = {
 	/* Broadcom BCM2033 without firmware */
 	{ USB_DEVICE(0x0a5c, 0x2033), .driver_info = BTUSB_IGNORE },
 
-	/* Broadcom BCM2045 devices */
+	/* Broadcom BCM2045 devices with Nintendo Wii firmware */
+	{ USB_DEVICE(0x057e, 0x0305), .driver_info = BTUSB_IGNORE },
+
+	/* Broadcom BCM2045 devices with common firmware */
 	{ USB_DEVICE(0x0a5c, 0x2045), .driver_info = BTUSB_BCM2045 },
 
 	/* Atheros 3011 with sflash firmware */


### PR DESCRIPTION
The Nintendo Wii uses a BCM2045 module running proprietary firmware.
This adapter is typically managed by emulation software via the raw
interface, and is incompatible with standard Bluetooth devices.

Attempting to initialize this adapter breaks synchronization with all
previously connected Wii Remotes, requiring applications to
re-synchronize the remotes on each usage.

Fix Wii Remote re-synchronization issues with the official Nintendo Wii
Bluetooth module by ignoring this adapter.

Signed-off-by: Alan Jones <j.alan.jones@pm.me>
---
 drivers/bluetooth/btusb.c | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)