### PR TITLE
[PW_SID:918106] [v1] Bluetooth: hci_sync: Fix disconnect complete event timeout issue

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          path: src/src
+
+      - name: CI
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: ci
+          base_folder: src
+          space: kernel
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,36 @@
+name: Snyc
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Sync Repo
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: sync
+          upstream_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sync Patchwork
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: patchwork
+          space: kernel
+          github_token: ${{ secrets.ACTION_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/include/net/bluetooth/hci_core.h
+++ b/include/net/bluetooth/hci_core.h
@@ -753,6 +753,8 @@ struct hci_conn {
 
 	struct bt_codec codec;
 
+	struct completion disc_ev_comp;
+
 	void (*connect_cfm_cb)	(struct hci_conn *conn, u8 status);
 	void (*security_cfm_cb)	(struct hci_conn *conn, u8 status);
 	void (*disconn_cfm_cb)	(struct hci_conn *conn, u8 reason);

--- a/net/bluetooth/hci_conn.c
+++ b/net/bluetooth/hci_conn.c
@@ -1028,6 +1028,15 @@ static struct hci_conn *__hci_conn_add(struct hci_dev *hdev, int type, bdaddr_t 
 
 	hci_conn_init_sysfs(conn);
 
+	/* This disc_ev_comp is inited when we send a disconnect request to
+	 * the remote device but fail to receive the disconnect complete
+	 * event within the expected time (2 seconds). This occurs because
+	 * the remote device doesn't ack the terminate indication, forcing
+	 * the controller to wait for the supervision timeout.
+	 */
+	init_completion(&conn->disc_ev_comp);
+	complete(&conn->disc_ev_comp);
+
 	return conn;
 }
 


### PR DESCRIPTION
Sometimes, the remote device doesn't acknowledge the LL_TERMINATE_IND
in time, requiring the controller to wait for the supervision timeout,
which may exceed 2 seconds. In the current implementation, the
HCI_EV_DISCONN_COMPLETE event is ignored if it arrives late, since
the hci_abort_conn_sync has cleaned up the connection after 2 seconds.
This causes the mgmt to get stuck, resulting in bluetoothd waiting
indefinitely for the mgmt response to the disconnect. To recover,
restarting bluetoothd is necessary.

bluetoothctl log like this:
[Designer Mouse]# disconnect D9:B5:6C:F2:51:91
Attempting to disconnect from D9:B5:6C:F2:51:91
[Designer Mouse]#
[Designer Mouse]# power off
[Designer Mouse]#
Failed to set power off: org.freedesktop.DBus.Error.NoReply.

Signed-off-by: Cheng Jiang <quic_chejiang@quicinc.com>
---
 include/net/bluetooth/hci_core.h |  2 ++
 net/bluetooth/hci_conn.c         |  9 +++++++++
 net/bluetooth/hci_event.c        |  9 +++++++++
 net/bluetooth/hci_sync.c         | 18 ++++++++++++++++++
 4 files changed, 38 insertions(+)


base-commit: e25c8d66f6786300b680866c0e0139981273feba