### PR TITLE
[PW_SID:920408] Enable Bluetooth on qcs6490-rb3gen2 board

### DIFF
--- a/Documentation/devicetree/bindings/net/bluetooth/qualcomm-bluetooth.yaml
+++ b/Documentation/devicetree/bindings/net/bluetooth/qualcomm-bluetooth.yaml
@@ -154,16 +154,11 @@ allOf:
               - qcom,wcn6750-bt
     then:
       required:
-        - enable-gpios
-        - swctrl-gpios
-        - vddio-supply
         - vddaon-supply
-        - vddbtcxmx-supply
         - vddrfacmn-supply
         - vddrfa0p8-supply
         - vddrfa1p7-supply
         - vddrfa1p2-supply
-        - vddasd-supply
   - if:
       properties:
         compatible:


### PR DESCRIPTION
Drop the inputs from the host and instead expect the Bluetooth node to
consume the outputs of the internal PMU.

Signed-off-by: Janaki Ramaiah Thota <quic_janathot@quicinc.com>
---
 .../bindings/net/bluetooth/qualcomm-bluetooth.yaml           | 5 -----
 1 file changed, 5 deletions(-)