### PR TITLE
[PW_SID:921080] Bluetooth: btbcm: Fix NULL deref in btbcm_get_board_name()

### DIFF
--- a/drivers/bluetooth/btbcm.c
+++ b/drivers/bluetooth/btbcm.c
@@ -553,6 +553,9 @@ static const char *btbcm_get_board_name(struct device *dev)
 
 	/* get rid of any '/' in the compatible string */
 	board_type = devm_kstrdup(dev, tmp, GFP_KERNEL);
+	if (!board_type)
+		return -ENOMEM;
+
 	strreplace(board_type, '/', '-');
 
 	return board_type;


### PR DESCRIPTION
devm_kstrdup() can return a NULL pointer on failure,but this
returned value in btbcm_get_board_name() is not checked.
Add NULL check in btbcm_get_board_name(), to handle kernel NULL
pointer dereference error.

Fixes: f9183eaad915 ("Bluetooth: btbcm: Use devm_kstrdup()")
Signed-off-by: Charles Han <hanchunchao@inspur.com>
---
 drivers/bluetooth/btbcm.c | 3 +++
 1 file changed, 3 insertions(+)