### PR TITLE
[PW_SID:926859] Bluetooth: Add ABI doc for sysfs reset

### DIFF
--- a/Documentation/ABI/stable/sysfs-class-bluetooth
+++ b/Documentation/ABI/stable/sysfs-class-bluetooth
@@ -1,0 +1,9 @@
+What: 		/sys/class/bluetooth/hci<index>/reset
+Date:		14-Jan-2025
+KernelVersion:	6.13
+Contact:	linux-bluetooth@vger.kernel.org
+Description: 	This write-only attribute allows users to trigger the vendor reset
+		method on the Bluetooth device when an arbitrary data is written.
+		The reset may or may not be done through the device transport
+		(e.g., UART/USB), and can through an out-of-band approach such as
+		GPIO.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -4058,6 +4058,7 @@ S:	Supported
 W:	http://www.bluez.org/
 T:	git git://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth.git
 T:	git git://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git
+F:	Documentation/ABI/stable/sysfs-class-bluetooth
 F:	include/net/bluetooth/
 F:	net/bluetooth/
 


### PR DESCRIPTION
From: Hsin-chen Chuang <chharry@chromium.org>

The functionality was implemented in commit 0f8a00137411 ("Bluetooth:
Allow reset via sysfs")

Signed-off-by: Hsin-chen Chuang <chharry@chromium.org>
---

 Documentation/ABI/stable/sysfs-class-bluetooth | 9 +++++++++
 MAINTAINERS                                    | 1 +
 2 files changed, 10 insertions(+)
 create mode 100644 Documentation/ABI/stable/sysfs-class-bluetooth