### PR TITLE
[PW_SID:938683] Bluetooth: SCO: fix sco_conn refcounting on sco_conn_ready

### DIFF
--- a/net/bluetooth/sco.c
+++ b/net/bluetooth/sco.c
@@ -1353,6 +1353,7 @@ static void sco_conn_ready(struct sco_conn *conn)
 		bacpy(&sco_pi(sk)->src, &conn->hcon->src);
 		bacpy(&sco_pi(sk)->dst, &conn->hcon->dst);
 
+		sco_conn_hold_unless_zero(conn);
 		hci_conn_hold(conn->hcon);
 		__sco_chan_add(conn, sk, parent);
 
@@ -1411,8 +1412,10 @@ static void sco_connect_cfm(struct hci_conn *hcon, __u8 status)
 		struct sco_conn *conn;
 
 		conn = sco_conn_add(hcon);
-		if (conn)
+		if (conn) {
 			sco_conn_ready(conn);
+			sco_conn_put(conn);
+		}
 	} else
 		sco_conn_del(hcon, bt_to_errno(status));
 }


### PR DESCRIPTION
sco_conn refcount shall not be incremented a second time if the sk
already owns the refcount.

Fixes SCO socket shutdown not actually closing the SCO socket.

Fixes: e6720779ae61 ("Bluetooth: SCO: Use kref to track lifetime of sco_conn")
---

Notes:
    Making the sco_conn_add refcounts consistent in ed9588554943 exposed the
    issue here.
    
    I think this should fix the situation, but didn't yet test this in real
    use, only the sco-tester test case.

 net/bluetooth/sco.c | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)