### PR TITLE
[PW_SID:941316] [v1] Bluetooth: btintel: Fix leading white space

### DIFF
--- a/drivers/bluetooth/btintel.h
+++ b/drivers/bluetooth/btintel.h
@@ -56,7 +56,7 @@ struct intel_tlv {
 #define BTINTEL_CNVI_BLAZARIW		0x901
 #define BTINTEL_CNVI_GAP		0x910
 #define BTINTEL_CNVI_BLAZARU		0x930
- #define BTINTEL_CNVI_SCP		0xA00
+#define BTINTEL_CNVI_SCP		0xA00
 
 #define BTINTEL_IMG_BOOTLOADER		0x01	/* Bootloader image */
 #define BTINTEL_IMG_IML			0x02	/* Intermediate image */


### PR DESCRIPTION
Remove the unwanted leading whitespace.

Fixes: f5d8a90511b7 ("Bluetooth: btintel: Add DSBR support for ScP")
Signed-off-by: Kiran K <kiran.k@intel.com>
---
 drivers/bluetooth/btintel.h | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)