### PR TITLE
[PW_SID:944837] [v1] HCI: coredump: Log devcd dumps into the monitor

### DIFF
--- a/net/bluetooth/coredump.c
+++ b/net/bluetooth/coredump.c
@@ -257,6 +257,12 @@ static void hci_devcd_handle_pkt_complete(struct hci_dev *hdev,
 		   hdev->dump.alloc_size);
 
 	dev_coredumpv(&hdev->dev, hdev->dump.head, dump_size, GFP_KERNEL);
+
+	skb = bt_skb_alloc(dump_size, GFP_ATOMIC);
+	if (skb) {
+		skb_put_data(skb, hdev->dump.head, dump_size);
+		hci_recv_diag(hdev, skb);
+	}
 }
 
 static void hci_devcd_handle_pkt_abort(struct hci_dev *hdev,
@@ -277,6 +283,12 @@ static void hci_devcd_handle_pkt_abort(struct hci_dev *hdev,
 
 	/* Emit a devcoredump with the available data */
 	dev_coredumpv(&hdev->dev, hdev->dump.head, dump_size, GFP_KERNEL);
+
+	skb = bt_skb_alloc(dump_size, GFP_ATOMIC);
+	if (skb) {
+		skb_put_data(skb, hdev->dump.head, dump_size);
+		hci_recv_diag(hdev, skb);
+	}
 }
 
 /* Bluetooth devcoredump state machine.


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This logs the devcd dumps with hci_recv_diag so they appear in the
monitor traces with proper timestamps which can then be used to relate
the HCI traffic that caused the dump:

= Vendor Diagnostic (len 174)
        42 6c 75 65 74 6f 6f 74 68 20 64 65 76 63 6f 72  Bluetooth devcor
        65 64 75 6d 70 0a 53 74 61 74 65 3a 20 32 0a 00  edump.State: 2..
        43 6f 6e 74 72 6f 6c 6c 65 72 20 4e 61 6d 65 3a  Controller Name:
        20 76 68 63 69 5f 63 74 72 6c 0a 46 69 72 6d 77   vhci_ctrl.Firmw
        61 72 65 20 56 65 72 73 69 6f 6e 3a 20 76 68 63  are Version: vhc
        69 5f 66 77 0a 44 72 69 76 65 72 3a 20 76 68 63  i_fw.Driver: vhc
        69 5f 64 72 76 0a 56 65 6e 64 6f 72 3a 20 76 68  i_drv.Vendor: vh
        63 69 0a 2d 2d 2d 20 53 74 61 72 74 20 64 75 6d  ci.--- Start dum
        70 20 2d 2d 2d 0a 74 65 73 74 20 64 61 74 61 00  p ---.test data.
        00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
        00 00 00 00 00 00 00 00 00 00 00 00 00 00        ..............

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
---
 net/bluetooth/coredump.c | 12 ++++++++++++
 1 file changed, 12 insertions(+)