### PR TITLE
[PW_SID:948479] Bluetooth: btusb: Reset altsetting when no SCO connection

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          path: src/src
+
+      - name: CI
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: ci
+          base_folder: src
+          space: kernel
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,36 @@
+name: Snyc
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Sync Repo
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: sync
+          upstream_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sync Patchwork
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: patchwork
+          space: kernel
+          github_token: ${{ secrets.ACTION_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/drivers/bluetooth/Kconfig
+++ b/drivers/bluetooth/Kconfig
@@ -56,17 +56,23 @@ config BT_HCIBTUSB_POLL_SYNC
 	  Say Y here to enable USB poll_sync for Bluetooth USB devices by
 	  default.
 
-config BT_HCIBTUSB_AUTO_ISOC_ALT
-	bool "Automatically adjust alternate setting for Isoc endpoints"
+config BT_HCIBTUSB_AUTO_ISOC_ALT_MAX_HANDLES
+	int "Automatically adjust alternate setting for Isoc endpoints"
 	depends on BT_HCIBTUSB
-	default y if CHROME_PLATFORMS
+	default 2 if CHROME_PLATFORMS
+	default 0
 	help
-	  Say Y here to automatically adjusting the alternate setting for
-	  HCI_USER_CHANNEL whenever a SCO link is established.
+	  Say positive number here to automatically adjusting the alternate
+	  setting for HCI_USER_CHANNEL whenever a SCO link is established.
 
-	  When enabled, btusb intercepts the HCI_EV_SYNC_CONN_COMPLETE packets
+	  When positive, btusb intercepts the HCI_EV_SYNC_CONN_COMPLETE packets
 	  and configures isoc endpoint alternate setting automatically when
 	  HCI_USER_CHANNEL is in use.
+	  btusb traces at most the given number of SCO handles and intercepts
+	  the HCI_EV_DISCONN_COMPLETE and the HCI_EV_CMD_COMPLETE of
+	  HCI_OP_RESET packets. When the controller is reset, or all tracing
+	  handles are disconnected, btusb reset the isoc endpoint alternate
+	  setting to zero.
 
 config BT_HCIBTUSB_BCM
 	bool "Broadcom protocol support"


### PR DESCRIPTION
From: Hsin-chen Chuang <chharry@chromium.org>

Although commit 75ddcd5ad40e ("Bluetooth: btusb: Configure altsetting
for HCI_USER_CHANNEL") has enabled the HCI_USER_CHANNEL user to send out
SCO data through USB Bluetooth chips, it's observed that with the patch
HFP is flaky on most of the existing USB Bluetooth controllers: Intel
chips sometimes send out no packet for Transparent codec; MTK chips may
generate SCO data with a wrong handle for CVSD codec; RTK could split
the data with a wrong packet size for Transparent codec.

To address the issue above btusb needs to reset the altsetting back to
zero when there is no active SCO connection, which is the same as the
BlueZ behavior, and another benefit is the bus doesn't need to reserve
bandwidth when no SCO connection.

This patch adds a fixed-size array in btusb_data which is used for
tracing the active SCO handles. When the controller is reset or any
tracing handle has disconnected, btusb adjusts the USB alternate setting
correspondingly for the Isoc endpoint.

The array size is configured by BT_HCIBTUSB_AUTO_ISOC_ALT_MAX_HANDLES.
If the size is set to zero, the auto set altsetting feature is disabled.

This patch is tested on ChromeOS devices. The USB Bluetooth models
(CVSD, TRANS alt3 and alt6) could pass the stress HFP test narrow band
speech and wide band speech.

Cc: chromeos-bluetooth-upstreaming@chromium.org
Fixes: 75ddcd5ad40e ("Bluetooth: btusb: Configure altsetting for HCI_USER_CHANNEL")
Signed-off-by: Hsin-chen Chuang <chharry@chromium.org>
---

 drivers/bluetooth/Kconfig |  18 ++++--
 drivers/bluetooth/btusb.c | 116 ++++++++++++++++++++++++++++++--------
 2 files changed, 105 insertions(+), 29 deletions(-)