### PR TITLE
[PW_SID:956731] Bluetooth: L2CAP: copy RX timestamp to new fragments

### DIFF
--- a/net/bluetooth/l2cap_core.c
+++ b/net/bluetooth/l2cap_core.c
@@ -7415,6 +7415,9 @@ static int l2cap_recv_frag(struct l2cap_conn *conn, struct sk_buff *skb,
 			return -ENOMEM;
 		/* Init rx_len */
 		conn->rx_len = len;
+
+		skb_set_delivery_time(conn->rx_skb, skb->tstamp,
+				      skb->tstamp_type);
 	}
 
 	/* Copy as much as the rx_skb can hold */


### PR DESCRIPTION
Copy timestamp too when allocating new skb for received fragment.
Fixes missing RX timestamps with fragmentation.

Signed-off-by: Pauli Virtanen <pav@iki.fi>
---
 net/bluetooth/l2cap_core.c | 3 +++
 1 file changed, 3 insertions(+)