### PR TITLE
[PW_SID:974106] [net-next] Bluetooth: Remove hci_conn_hash_lookup_state()

### DIFF
--- a/include/net/bluetooth/hci_core.h
+++ b/include/net/bluetooth/hci_core.h
@@ -1417,26 +1417,6 @@ hci_conn_hash_lookup_pa_sync_handle(struct hci_dev *hdev, __u16 sync_handle)
 	return NULL;
 }
 
-static inline struct hci_conn *hci_conn_hash_lookup_state(struct hci_dev *hdev,
-							__u8 type, __u16 state)
-{
-	struct hci_conn_hash *h = &hdev->conn_hash;
-	struct hci_conn  *c;
-
-	rcu_read_lock();
-
-	list_for_each_entry_rcu(c, &h->list, list) {
-		if (c->type == type && c->state == state) {
-			rcu_read_unlock();
-			return c;
-		}
-	}
-
-	rcu_read_unlock();
-
-	return NULL;
-}
-
 typedef void (*hci_conn_func_t)(struct hci_conn *conn, void *data);
 static inline void hci_conn_hash_list_state(struct hci_dev *hdev,
 					    hci_conn_func_t func, __u8 type,


### PR DESCRIPTION
Since commit 4aa42119d971 ("Bluetooth: Remove pending ACL connection
attempts") this function is unused.

Signed-off-by: Yue Haibing <yuehaibing@huawei.com>
---
 include/net/bluetooth/hci_core.h | 20 --------------------
 1 file changed, 20 deletions(-)