### PR TITLE
[PW_SID:979318] Bluetooth: btusb: Fix potential NULL dereference on kmalloc failure

### DIFF
--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -3799,6 +3799,8 @@ static int btusb_hci_drv_supported_altsettings(struct hci_dev *hdev, void *data,
 
 	/* There are at most 7 alt (0 - 6) */
 	rp = kmalloc(sizeof(*rp) + 7, GFP_KERNEL);
+	if (!rp)
+		return -ENOMEM;
 
 	rp->num = 0;
 	if (!drvdata->isoc)


### PR DESCRIPTION
Avoid potential NULL pointer dereference by checking the return value of
kmalloc and handling allocation failure properly.

Fixes: 7d70989fcea7 ("Bluetooth: btusb: Add HCI Drv commands for configuring altsetting")
Signed-off-by: Zhongqiu Han <quic_zhonhan@quicinc.com>
---
 drivers/bluetooth/btusb.c | 2 ++
 1 file changed, 2 insertions(+)