### PR TITLE
[PW_SID:982752] [v2] Bluetooth: coredump: Use tmp buffer with dev_coredumpv

### DIFF
--- a/net/bluetooth/coredump.c
+++ b/net/bluetooth/coredump.c
@@ -243,6 +243,7 @@ static void hci_devcd_handle_pkt_pattern(struct hci_dev *hdev,
 static void hci_devcd_dump(struct hci_dev *hdev)
 {
 	struct sk_buff *skb;
+	char *coredump;
 	u32 size;
 
 	bt_dev_dbg(hdev, "state %d", hdev->dump.state);
@@ -250,7 +251,11 @@ static void hci_devcd_dump(struct hci_dev *hdev)
 	size = hdev->dump.tail - hdev->dump.head;
 
 	/* Emit a devcoredump with the available data */
-	dev_coredumpv(&hdev->dev, hdev->dump.head, size, GFP_KERNEL);
+	coredump = vmalloc(size);
+	if (coredump) {
+		memcpy(coredump, hdev->dump.head, size);
+		dev_coredumpv(&hdev->dev, coredump, size, GFP_KERNEL);
+	}
 
 	/* Send a copy to monitor as a diagnostic packet */
 	skb = bt_skb_alloc(size, GFP_ATOMIC);


### PR DESCRIPTION
Create and use new vmalloc'ed buffer with dev_coredumpv. From
dev_coredumpv documentation:

`This function takes ownership of the vmalloc'ed data and will free
it when it is no longer used.`

As hdev->dump is used after dev_coredumpv, create temporary buffer to
hold hdev->dump data.

Reported-by: syzbot+ac3c79181f6aecc5120c@syzkaller.appspotmail.com
Closes: https://lore.kernel.org/all/67eaa688.050a0220.1547ec.014a.GAE@google.com
Fixes: b257e02ecc46 ("HCI: coredump: Log devcd dumps into the monitor")
Signed-off-by: Ivan Pravdin <ipravdin.official@gmail.com>
---
v1 -> v2: Changed subject prefix to Bluetooth:

 net/bluetooth/coredump.c | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)