### PR TITLE
[PW_SID:992737] [v2,1/8] Bluetooth: hci_core: Convert instances of BT_DBG to bt_dev_dbg

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          path: src/src
+
+      - name: CI
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: ci
+          base_folder: src
+          space: kernel
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,36 @@
+name: Snyc
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Sync Repo
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: sync
+          upstream_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sync Patchwork
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: patchwork
+          space: kernel
+          github_token: ${{ secrets.ACTION_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/include/net/bluetooth/bluetooth.h
+++ b/include/net/bluetooth/bluetooth.h
@@ -272,7 +272,8 @@ void bt_err_ratelimited(const char *fmt, ...);
 #define BT_ERR(fmt, ...)	bt_err(fmt "\n", ##__VA_ARGS__)
 
 #if IS_ENABLED(CONFIG_BT_FEATURE_DEBUG)
-#define BT_DBG(fmt, ...)	bt_dbg(fmt "\n", ##__VA_ARGS__)
+#define BT_DBG(fmt, ...) \
+	bt_dbg("%s:%d: " fmt "\n", __func__, __LINE__, ##__VA_ARGS__)
 #else
 #define BT_DBG(fmt, ...)	pr_debug(fmt "\n", ##__VA_ARGS__)
 #endif

--- a/include/net/bluetooth/hci_core.h
+++ b/include/net/bluetooth/hci_core.h
@@ -1704,6 +1704,14 @@ static inline struct hci_dev *hci_dev_hold(struct hci_dev *d)
 #define to_hci_dev(d) container_of(d, struct hci_dev, dev)
 #define to_hci_conn(c) container_of(c, struct hci_conn, dev)
 
+#define hci_conn_set_state(c, s) \
+	do { \
+		bt_dev_dbg((c)->hdev, "hcon %p handle 0x%04x state %s -> %s", \
+			   (c), (c)->handle, state_to_string((c)->state), \
+			   state_to_string(s)); \
+		(c)->state = s; \
+	} while (0)
+
 static inline void *hci_get_drvdata(struct hci_dev *hdev)
 {
 	return dev_get_drvdata(&hdev->dev);
@@ -2133,7 +2141,7 @@ static inline void hci_encrypt_cfm(struct hci_conn *conn, __u8 status)
 
 	if (conn->state == BT_CONFIG) {
 		if (!status)
-			conn->state = BT_CONNECTED;
+			hci_conn_set_state(conn, BT_CONNECTED);
 
 		hci_connect_cfm(conn, status);
 		hci_conn_drop(conn);

--- a/net/bluetooth/hci_conn.c
+++ b/net/bluetooth/hci_conn.c
@@ -38,6 +38,14 @@
 #include "smp.h"
 #include "eir.h"
 
+#define bt_conn_hdev(conn) ((conn) ? (conn)->hdev : NULL)
+#define bt_conn_handle(conn) ((conn) ? (conn)->handle : 0)
+#define bt_conn_state_str(conn) ((conn) ? state_to_string((conn)->state) : NULL)
+#define bt_conn_dbg(conn, fmt, ...) \
+	bt_dev_dbg(bt_conn_hdev(conn), "hcon %p handle 0x%4.4x state %s" fmt, \
+		   conn, bt_conn_handle(conn), bt_conn_state_str(conn), \
+		   ##__VA_ARGS__)
+
 struct sco_param {
 	u16 pkt_type;
 	u16 max_latency;
@@ -177,7 +185,7 @@ static void hci_conn_cleanup(struct hci_conn *conn)
 
 int hci_disconnect(struct hci_conn *conn, __u8 reason)
 {
-	bt_dev_dbg(conn->hdev, "hcon %p", conn);
+	bt_conn_dbg(conn, "");
 
 	/* When we are central of an established connection and it enters
 	 * the disconnect timeout, then go ahead and try to read the
@@ -202,7 +210,7 @@ static void hci_add_sco(struct hci_conn *conn, __u16 handle)
 	struct hci_dev *hdev = conn->hdev;
 	struct hci_cp_add_sco cp;
 
-	bt_dev_dbg(hdev, "hcon %p", conn);
+	bt_conn_dbg(conn, "");
 
 	hci_conn_set_state(conn, BT_CONNECT);
 	conn->out = true;
@@ -225,9 +233,8 @@ static bool find_next_esco_param(struct hci_conn *conn,
 		if (lmp_esco_2m_capable(conn->parent) ||
 		    (esco_param[conn->attempt - 1].pkt_type & ESCO_2EV3))
 			break;
-		bt_dev_dbg(conn->hdev,
-			   "hcon %p skipped attempt %d, eSCO 2M not supported",
-			   conn, conn->attempt);
+		bt_conn_dbg(conn, "skipped attempt %d, eSCO 2M not supported",
+			    conn->attempt);
 	}
 
 	return conn->attempt <= size;
@@ -292,7 +299,7 @@ static int hci_enhanced_setup_sync(struct hci_dev *hdev, void *data)
 	if (!hci_conn_valid(hdev, conn))
 		return -ECANCELED;
 
-	bt_dev_dbg(hdev, "hcon %p", conn);
+	bt_conn_dbg(conn, "");
 
 	configure_datapath_sync(hdev, &conn->codec);
 
@@ -411,7 +418,7 @@ static bool hci_setup_sync_conn(struct hci_conn *conn, __u16 handle)
 	struct hci_cp_setup_sync_conn cp;
 	const struct sco_param *param;
 
-	bt_dev_dbg(hdev, "hcon %p", conn);
+	bt_conn_dbg(conn, "");
 
 	hci_conn_set_state(conn, BT_CONNECT);
 	conn->out = true;
@@ -523,7 +530,7 @@ void hci_le_start_enc(struct hci_conn *conn, __le16 ediv, __le64 rand,
 	struct hci_dev *hdev = conn->hdev;
 	struct hci_cp_le_start_enc cp;
 
-	bt_dev_dbg(hdev, "hcon %p", conn);
+	bt_conn_dbg(conn, "");
 
 	memset(&cp, 0, sizeof(cp));
 
@@ -544,7 +551,7 @@ void hci_sco_setup(struct hci_conn *conn, __u8 status)
 	if (!link || !link->conn)
 		return;
 
-	bt_dev_dbg(conn->hdev, "hcon %p", conn);
+	bt_conn_dbg(conn, "");
 
 	if (!status) {
 		if (lmp_esco_capable(conn->hdev))
@@ -563,8 +570,7 @@ static void hci_conn_timeout(struct work_struct *work)
 					     disc_work.work);
 	int refcnt = atomic_read(&conn->refcnt);
 
-	bt_dev_dbg(conn->hdev, "hcon %p state %s", conn,
-		   state_to_string(conn->state));
+	bt_conn_dbg(conn, "state %s", state_to_string(conn->state));
 
 	WARN_ON(refcnt < 0);
 
@@ -588,7 +594,7 @@ static void hci_conn_idle(struct work_struct *work)
 					     idle_work.work);
 	struct hci_dev *hdev = conn->hdev;
 
-	bt_dev_dbg(hdev, "hcon %p mode %d", conn, conn->mode);
+	bt_conn_dbg(conn, "mode %d", conn->mode);
 
 	if (!lmp_sniff_capable(hdev) || !lmp_sniff_capable(conn))
 		return;
@@ -648,7 +654,7 @@ static void le_conn_timeout(struct work_struct *work)
 					     le_conn_timeout.work);
 	struct hci_dev *hdev = conn->hdev;
 
-	bt_dev_dbg(hdev, "");
+	bt_conn_dbg(conn, "");
 
 	/* We could end up here due to having done directed advertising,
 	 * so clean up the state if necessary. This should however only
@@ -823,7 +829,7 @@ static void bis_cleanup(struct hci_conn *conn)
 	struct hci_dev *hdev = conn->hdev;
 	struct hci_conn *bis;
 
-	bt_dev_dbg(hdev, "hcon %p", conn);
+	bt_conn_dbg(conn, "");
 
 	if (conn->role == HCI_ROLE_MASTER) {
 		if (!test_and_clear_bit(HCI_CONN_PER_ADV, &conn->flags))
@@ -1102,7 +1108,7 @@ static void hci_conn_unlink(struct hci_conn *conn)
 {
 	struct hci_dev *hdev = conn->hdev;
 
-	bt_dev_dbg(hdev, "hcon %p", conn);
+	bt_conn_dbg(conn, "");
 
 	if (!conn->parent) {
 		struct hci_link *link, *t;
@@ -1144,7 +1150,7 @@ void hci_conn_del(struct hci_conn *conn)
 {
 	struct hci_dev *hdev = conn->hdev;
 
-	bt_dev_dbg(hdev, "hcon %p handle %d", conn, conn->handle);
+	bt_conn_dbg(conn, "");
 
 	hci_conn_unlink(conn);
 
@@ -1294,7 +1300,7 @@ void hci_conn_failed(struct hci_conn *conn, u8 status)
 {
 	struct hci_dev *hdev = conn->hdev;
 
-	bt_dev_dbg(hdev, "status 0x%2.2x", status);
+	bt_conn_dbg(conn, "status 0x%2.2x", status);
 
 	switch (conn->type) {
 	case LE_LINK:
@@ -1321,7 +1327,7 @@ u8 hci_conn_set_handle(struct hci_conn *conn, u16 handle)
 {
 	struct hci_dev *hdev = conn->hdev;
 
-	bt_dev_dbg(hdev, "hcon %p handle 0x%4.4x", conn, handle);
+	bt_conn_dbg(conn, "");
 
 	if (conn->handle == handle)
 		return 0;
@@ -2170,7 +2176,7 @@ static void create_big_complete(struct hci_dev *hdev, void *data, int err)
 {
 	struct hci_conn *conn = data;
 
-	bt_dev_dbg(hdev, "hcon %p", conn);
+	bt_conn_dbg(conn, "");
 
 	if (err) {
 		bt_dev_err(hdev, "Unable to create BIG: %d", err);
@@ -2352,7 +2358,7 @@ struct hci_conn *hci_connect_cis(struct hci_dev *hdev, bdaddr_t *dst,
 /* Check link security requirement */
 int hci_conn_check_link_mode(struct hci_conn *conn)
 {
-	bt_dev_dbg(conn->hdev, "hcon %p", conn);
+	bt_conn_dbg(conn, "");
 
 	/* In Secure Connections Only mode, it is required that Secure
 	 * Connections is used and the link is encrypted with AES-CCM
@@ -2392,7 +2398,7 @@ int hci_conn_check_link_mode(struct hci_conn *conn)
 /* Authenticate remote device */
 static int hci_conn_auth(struct hci_conn *conn, __u8 sec_level, __u8 auth_type)
 {
-	bt_dev_dbg(conn->hdev, "hcon %p", conn);
+	bt_conn_dbg(conn, "");
 
 	if (conn->pending_sec_level > sec_level)
 		sec_level = conn->pending_sec_level;
@@ -2427,7 +2433,7 @@ static int hci_conn_auth(struct hci_conn *conn, __u8 sec_level, __u8 auth_type)
 /* Encrypt the link */
 static void hci_conn_encrypt(struct hci_conn *conn)
 {
-	bt_dev_dbg(conn->hdev, "hcon %p", conn);
+	bt_conn_dbg(conn, "");
 
 	if (!test_and_set_bit(HCI_CONN_ENCRYPT_PEND, &conn->flags)) {
 		struct hci_cp_set_conn_encrypt cp;
@@ -2442,8 +2448,8 @@ static void hci_conn_encrypt(struct hci_conn *conn)
 int hci_conn_security(struct hci_conn *conn, __u8 sec_level, __u8 auth_type,
 		      bool initiator)
 {
-	bt_dev_dbg(conn->hdev, "hcon %p sec_level %d auth_type %d initiator %d",
-		   conn, sec_level, auth_type, initiator);
+	bt_conn_dbg(conn, "sec_level %d auth_type %d initiator %d",
+		    sec_level, auth_type, initiator);
 
 	if (conn->type == LE_LINK)
 		return smp_conn_security(conn, sec_level);
@@ -2527,7 +2533,7 @@ EXPORT_SYMBOL(hci_conn_security);
 /* Check secure link requirement */
 int hci_conn_check_secure(struct hci_conn *conn, __u8 sec_level)
 {
-	bt_dev_dbg(conn->hdev, "hcon %p sec_level %u", conn, sec_level);
+	bt_conn_dbg(conn, "sec_level %u", sec_level);
 
 	/* Accept if non-secure or higher security level is required */
 	if (sec_level != BT_SECURITY_HIGH && sec_level != BT_SECURITY_FIPS)
@@ -2546,7 +2552,7 @@ EXPORT_SYMBOL(hci_conn_check_secure);
 /* Switch role */
 int hci_conn_switch_role(struct hci_conn *conn, __u8 role)
 {
-	bt_dev_dbg(conn->hdev, "hcon %p role %u", conn, role);
+	bt_conn_dbg(conn, "role %u", role);
 
 	if (role == conn->role)
 		return 1;
@@ -2567,7 +2573,7 @@ void hci_conn_enter_active_mode(struct hci_conn *conn, __u8 force_active)
 {
 	struct hci_dev *hdev = conn->hdev;
 
-	bt_dev_dbg(hdev, "hcon %p mode %d", conn, conn->mode);
+	bt_conn_dbg(conn, "mode %d", conn->mode);
 
 	if (conn->mode != HCI_CM_SNIFF)
 		goto timer;
@@ -2733,13 +2739,12 @@ int hci_get_auth_info(struct hci_dev *hdev, void __user *arg)
 
 struct hci_chan *hci_chan_create(struct hci_conn *conn)
 {
-	struct hci_dev *hdev = conn->hdev;
 	struct hci_chan *chan;
 
-	bt_dev_dbg(hdev, "hcon %p", conn);
+	bt_conn_dbg(conn, "");
 
 	if (test_bit(HCI_CONN_DROP, &conn->flags)) {
-		bt_dev_dbg(hdev, "Refusing to create new hci_chan");
+		bt_conn_dbg(conn, "Refusing to create new hci_chan");
 		return NULL;
 	}
 
@@ -2759,9 +2764,8 @@ struct hci_chan *hci_chan_create(struct hci_conn *conn)
 void hci_chan_del(struct hci_chan *chan)
 {
 	struct hci_conn *conn = chan->conn;
-	struct hci_dev *hdev = conn->hdev;
 
-	bt_dev_dbg(hdev, "hcon %p chan %p", conn, chan);
+	bt_conn_dbg(conn, "chan %p", chan);
 
 	list_del_rcu(&chan->list);
 
@@ -2780,7 +2784,7 @@ void hci_chan_list_flush(struct hci_conn *conn)
 {
 	struct hci_chan *chan, *n;
 
-	bt_dev_dbg(conn->hdev, "hcon %p", conn);
+	bt_conn_dbg(conn, "");
 
 	list_for_each_entry_safe(chan, n, &conn->chan_list, list)
 		hci_chan_del(chan);
@@ -2941,8 +2945,7 @@ int hci_abort_conn(struct hci_conn *conn, u8 reason)
 	if (conn->abort_reason)
 		return 0;
 
-	bt_dev_dbg(hdev, "hcon %p handle 0x%2.2x reason 0x%2.2x", conn,
-		   conn->handle, reason);
+	bt_conn_dbg(conn, "reason 0x%2.2x", reason);
 
 	conn->abort_reason = reason;
 

--- a/net/bluetooth/hci_conn.c
+++ b/net/bluetooth/hci_conn.c
@@ -177,7 +177,7 @@ static void hci_conn_cleanup(struct hci_conn *conn)
 
 int hci_disconnect(struct hci_conn *conn, __u8 reason)
 {
-	BT_DBG("hcon %p", conn);
+	bt_dev_dbg(conn->hdev, "hcon %p", conn);
 
 	/* When we are central of an established connection and it enters
 	 * the disconnect timeout, then go ahead and try to read the
@@ -202,7 +202,7 @@ static void hci_add_sco(struct hci_conn *conn, __u16 handle)
 	struct hci_dev *hdev = conn->hdev;
 	struct hci_cp_add_sco cp;
 
-	BT_DBG("hcon %p", conn);
+	bt_dev_dbg(hdev, "hcon %p", conn);
 
 	conn->state = BT_CONNECT;
 	conn->out = true;
@@ -225,8 +225,9 @@ static bool find_next_esco_param(struct hci_conn *conn,
 		if (lmp_esco_2m_capable(conn->parent) ||
 		    (esco_param[conn->attempt - 1].pkt_type & ESCO_2EV3))
 			break;
-		BT_DBG("hcon %p skipped attempt %d, eSCO 2M not supported",
-		       conn, conn->attempt);
+		bt_dev_dbg(conn->hdev,
+			   "hcon %p skipped attempt %d, eSCO 2M not supported",
+			   conn, conn->attempt);
 	}
 
 	return conn->attempt <= size;
@@ -522,7 +523,7 @@ void hci_le_start_enc(struct hci_conn *conn, __le16 ediv, __le64 rand,
 	struct hci_dev *hdev = conn->hdev;
 	struct hci_cp_le_start_enc cp;
 
-	BT_DBG("hcon %p", conn);
+	bt_dev_dbg(hdev, "hcon %p", conn);
 
 	memset(&cp, 0, sizeof(cp));
 
@@ -543,7 +544,7 @@ void hci_sco_setup(struct hci_conn *conn, __u8 status)
 	if (!link || !link->conn)
 		return;
 
-	BT_DBG("hcon %p", conn);
+	bt_dev_dbg(conn->hdev, "hcon %p", conn);
 
 	if (!status) {
 		if (lmp_esco_capable(conn->hdev))
@@ -562,7 +563,8 @@ static void hci_conn_timeout(struct work_struct *work)
 					     disc_work.work);
 	int refcnt = atomic_read(&conn->refcnt);
 
-	BT_DBG("hcon %p state %s", conn, state_to_string(conn->state));
+	bt_dev_dbg(conn->hdev, "hcon %p state %s", conn,
+		   state_to_string(conn->state));
 
 	WARN_ON(refcnt < 0);
 
@@ -586,7 +588,7 @@ static void hci_conn_idle(struct work_struct *work)
 					     idle_work.work);
 	struct hci_dev *hdev = conn->hdev;
 
-	BT_DBG("hcon %p mode %d", conn, conn->mode);
+	bt_dev_dbg(hdev, "hcon %p mode %d", conn, conn->mode);
 
 	if (!lmp_sniff_capable(hdev) || !lmp_sniff_capable(conn))
 		return;
@@ -646,7 +648,7 @@ static void le_conn_timeout(struct work_struct *work)
 					     le_conn_timeout.work);
 	struct hci_dev *hdev = conn->hdev;
 
-	BT_DBG("");
+	bt_dev_dbg(hdev, "");
 
 	/* We could end up here due to having done directed advertising,
 	 * so clean up the state if necessary. This should however only
@@ -774,7 +776,8 @@ static int hci_le_big_terminate(struct hci_dev *hdev, u8 big, struct hci_conn *c
 	struct iso_list_data *d;
 	int ret;
 
-	bt_dev_dbg(hdev, "big 0x%2.2x sync_handle 0x%4.4x", big, conn->sync_handle);
+	bt_dev_dbg(hdev, "big 0x%2.2x sync_handle 0x%4.4x", big,
+		   conn->sync_handle);
 
 	d = kzalloc(sizeof(*d), GFP_KERNEL);
 	if (!d)
@@ -820,7 +823,7 @@ static void bis_cleanup(struct hci_conn *conn)
 	struct hci_dev *hdev = conn->hdev;
 	struct hci_conn *bis;
 
-	bt_dev_dbg(hdev, "conn %p", conn);
+	bt_dev_dbg(hdev, "hcon %p", conn);
 
 	if (conn->role == HCI_ROLE_MASTER) {
 		if (!test_and_clear_bit(HCI_CONN_PER_ADV, &conn->flags))
@@ -1141,7 +1144,7 @@ void hci_conn_del(struct hci_conn *conn)
 {
 	struct hci_dev *hdev = conn->hdev;
 
-	BT_DBG("%s hcon %p handle %d", hdev->name, conn, conn->handle);
+	bt_dev_dbg(hdev, "hcon %p handle %d", conn, conn->handle);
 
 	hci_conn_unlink(conn);
 
@@ -1466,8 +1469,8 @@ static int hci_explicit_conn_params_set(struct hci_dev *hdev,
 
 	params->explicit_connect = true;
 
-	BT_DBG("addr %pMR (type %u) auto_connect %u", addr, addr_type,
-	       params->auto_connect);
+	bt_dev_dbg(hdev, "addr %pMR (type %u) auto_connect %u", addr, addr_type,
+		   params->auto_connect);
 
 	return 0;
 }
@@ -1619,7 +1622,7 @@ struct hci_conn *hci_connect_le_scan(struct hci_dev *hdev, bdaddr_t *dst,
 		goto done;
 	}
 
-	BT_DBG("requesting refresh of dst_addr");
+	bt_dev_dbg(hdev, "requesting refresh of dst_addr");
 
 	conn = hci_conn_add_unset(hdev, LE_LINK, dst, HCI_ROLE_MASTER);
 	if (IS_ERR(conn))
@@ -2167,7 +2170,7 @@ static void create_big_complete(struct hci_dev *hdev, void *data, int err)
 {
 	struct hci_conn *conn = data;
 
-	bt_dev_dbg(hdev, "conn %p", conn);
+	bt_dev_dbg(hdev, "hcon %p", conn);
 
 	if (err) {
 		bt_dev_err(hdev, "Unable to create BIG: %d", err);
@@ -2349,7 +2352,7 @@ struct hci_conn *hci_connect_cis(struct hci_dev *hdev, bdaddr_t *dst,
 /* Check link security requirement */
 int hci_conn_check_link_mode(struct hci_conn *conn)
 {
-	BT_DBG("hcon %p", conn);
+	bt_dev_dbg(conn->hdev, "hcon %p", conn);
 
 	/* In Secure Connections Only mode, it is required that Secure
 	 * Connections is used and the link is encrypted with AES-CCM
@@ -2389,7 +2392,7 @@ int hci_conn_check_link_mode(struct hci_conn *conn)
 /* Authenticate remote device */
 static int hci_conn_auth(struct hci_conn *conn, __u8 sec_level, __u8 auth_type)
 {
-	BT_DBG("hcon %p", conn);
+	bt_dev_dbg(conn->hdev, "hcon %p", conn);
 
 	if (conn->pending_sec_level > sec_level)
 		sec_level = conn->pending_sec_level;
@@ -2424,7 +2427,7 @@ static int hci_conn_auth(struct hci_conn *conn, __u8 sec_level, __u8 auth_type)
 /* Encrypt the link */
 static void hci_conn_encrypt(struct hci_conn *conn)
 {
-	BT_DBG("hcon %p", conn);
+	bt_dev_dbg(conn->hdev, "hcon %p", conn);
 
 	if (!test_and_set_bit(HCI_CONN_ENCRYPT_PEND, &conn->flags)) {
 		struct hci_cp_set_conn_encrypt cp;
@@ -2439,7 +2442,8 @@ static void hci_conn_encrypt(struct hci_conn *conn)
 int hci_conn_security(struct hci_conn *conn, __u8 sec_level, __u8 auth_type,
 		      bool initiator)
 {
-	BT_DBG("hcon %p", conn);
+	bt_dev_dbg(conn->hdev, "hcon %p sec_level %d auth_type %d initiator %d",
+		   conn, sec_level, auth_type, initiator);
 
 	if (conn->type == LE_LINK)
 		return smp_conn_security(conn, sec_level);
@@ -2523,7 +2527,7 @@ EXPORT_SYMBOL(hci_conn_security);
 /* Check secure link requirement */
 int hci_conn_check_secure(struct hci_conn *conn, __u8 sec_level)
 {
-	BT_DBG("hcon %p", conn);
+	bt_dev_dbg(conn->hdev, "hcon %p sec_level %u", conn, sec_level);
 
 	/* Accept if non-secure or higher security level is required */
 	if (sec_level != BT_SECURITY_HIGH && sec_level != BT_SECURITY_FIPS)
@@ -2542,7 +2546,7 @@ EXPORT_SYMBOL(hci_conn_check_secure);
 /* Switch role */
 int hci_conn_switch_role(struct hci_conn *conn, __u8 role)
 {
-	BT_DBG("hcon %p", conn);
+	bt_dev_dbg(conn->hdev, "hcon %p role %u", conn, role);
 
 	if (role == conn->role)
 		return 1;
@@ -2563,7 +2567,7 @@ void hci_conn_enter_active_mode(struct hci_conn *conn, __u8 force_active)
 {
 	struct hci_dev *hdev = conn->hdev;
 
-	BT_DBG("hcon %p mode %d", conn, conn->mode);
+	bt_dev_dbg(hdev, "hcon %p mode %d", conn, conn->mode);
 
 	if (conn->mode != HCI_CM_SNIFF)
 		goto timer;
@@ -2589,7 +2593,7 @@ void hci_conn_hash_flush(struct hci_dev *hdev)
 	struct list_head *head = &hdev->conn_hash.list;
 	struct hci_conn *conn;
 
-	BT_DBG("hdev %s", hdev->name);
+	bt_dev_dbg(hdev, "");
 
 	/* We should not traverse the list here, because hci_conn_del
 	 * can remove extra links, which may cause the list traversal
@@ -2732,10 +2736,10 @@ struct hci_chan *hci_chan_create(struct hci_conn *conn)
 	struct hci_dev *hdev = conn->hdev;
 	struct hci_chan *chan;
 
-	BT_DBG("%s hcon %p", hdev->name, conn);
+	bt_dev_dbg(hdev, "hcon %p", conn);
 
 	if (test_bit(HCI_CONN_DROP, &conn->flags)) {
-		BT_DBG("Refusing to create new hci_chan");
+		bt_dev_dbg(hdev, "Refusing to create new hci_chan");
 		return NULL;
 	}
 
@@ -2757,7 +2761,7 @@ void hci_chan_del(struct hci_chan *chan)
 	struct hci_conn *conn = chan->conn;
 	struct hci_dev *hdev = conn->hdev;
 
-	BT_DBG("%s hcon %p chan %p", hdev->name, conn, chan);
+	bt_dev_dbg(hdev, "hcon %p chan %p", conn, chan);
 
 	list_del_rcu(&chan->list);
 
@@ -2776,7 +2780,7 @@ void hci_chan_list_flush(struct hci_conn *conn)
 {
 	struct hci_chan *chan, *n;
 
-	BT_DBG("hcon %p", conn);
+	bt_dev_dbg(conn->hdev, "hcon %p", conn);
 
 	list_for_each_entry_safe(chan, n, &conn->chan_list, list)
 		hci_chan_del(chan);
@@ -2937,7 +2941,8 @@ int hci_abort_conn(struct hci_conn *conn, u8 reason)
 	if (conn->abort_reason)
 		return 0;
 
-	bt_dev_dbg(hdev, "handle 0x%2.2x reason 0x%2.2x", conn->handle, reason);
+	bt_dev_dbg(hdev, "hcon %p handle 0x%2.2x reason 0x%2.2x", conn,
+		   conn->handle, reason);
 
 	conn->abort_reason = reason;
 

--- a/net/bluetooth/hci_conn.c
+++ b/net/bluetooth/hci_conn.c
@@ -204,7 +204,7 @@ static void hci_add_sco(struct hci_conn *conn, __u16 handle)
 
 	bt_dev_dbg(hdev, "hcon %p", conn);
 
-	conn->state = BT_CONNECT;
+	hci_conn_set_state(conn, BT_CONNECT);
 	conn->out = true;
 
 	conn->attempt++;
@@ -296,7 +296,7 @@ static int hci_enhanced_setup_sync(struct hci_dev *hdev, void *data)
 
 	configure_datapath_sync(hdev, &conn->codec);
 
-	conn->state = BT_CONNECT;
+	hci_conn_set_state(conn, BT_CONNECT);
 	conn->out = true;
 
 	conn->attempt++;
@@ -413,7 +413,7 @@ static bool hci_setup_sync_conn(struct hci_conn *conn, __u16 handle)
 
 	bt_dev_dbg(hdev, "hcon %p", conn);
 
-	conn->state = BT_CONNECT;
+	hci_conn_set_state(conn, BT_CONNECT);
 	conn->out = true;
 
 	conn->attempt++;
@@ -1311,7 +1311,7 @@ void hci_conn_failed(struct hci_conn *conn, u8 status)
 	test_and_clear_bit(HCI_CONN_BIG_SYNC_FAILED, &conn->flags);
 	test_and_clear_bit(HCI_CONN_PA_SYNC_FAILED, &conn->flags);
 
-	conn->state = BT_CLOSED;
+	hci_conn_set_state(conn, BT_CLOSED);
 	hci_connect_cfm(conn, status);
 	hci_conn_del(conn);
 }
@@ -1582,7 +1582,7 @@ static struct hci_conn *hci_add_bis(struct hci_dev *hdev, bdaddr_t *dst,
 	if (IS_ERR(conn))
 		return conn;
 
-	conn->state = BT_CONNECT;
+	hci_conn_set_state(conn, BT_CONNECT);
 	conn->sid = sid;
 	conn->conn_timeout = timeout;
 
@@ -1633,7 +1633,7 @@ struct hci_conn *hci_connect_le_scan(struct hci_dev *hdev, bdaddr_t *dst,
 		return ERR_PTR(-EBUSY);
 	}
 
-	conn->state = BT_CONNECT;
+	hci_conn_set_state(conn, BT_CONNECT);
 	set_bit(HCI_CONN_SCANNING, &conn->flags);
 	conn->dst_type = dst_type;
 	conn->sec_level = BT_SECURITY_LOW;
@@ -2131,7 +2131,7 @@ struct hci_conn *hci_pa_create_sync(struct hci_dev *hdev, bdaddr_t *dst,
 	conn->iso_qos = *qos;
 	conn->dst_type = dst_type;
 	conn->sid = sid;
-	conn->state = BT_LISTEN;
+	hci_conn_set_state(conn, BT_LISTEN);
 	conn->conn_timeout = msecs_to_jiffies(qos->bcast.sync_timeout * 10);
 
 	hci_conn_hold(conn);
@@ -2193,7 +2193,7 @@ struct hci_conn *hci_bind_bis(struct hci_dev *hdev, bdaddr_t *dst, __u8 sid,
 					      HCI_ROLE_MASTER);
 	if (conn) {
 		memcpy(qos, &conn->iso_qos, sizeof(*qos));
-		conn->state = BT_CONNECTED;
+		hci_conn_set_state(conn, BT_CONNECTED);
 		return conn;
 	}
 
@@ -2221,7 +2221,7 @@ struct hci_conn *hci_bind_bis(struct hci_dev *hdev, bdaddr_t *dst, __u8 sid,
 			  hdev->le_tx_def_phys);
 
 	conn->iso_qos = *qos;
-	conn->state = BT_BOUND;
+	hci_conn_set_state(conn, BT_BOUND);
 
 	/* Link BISes together */
 	parent = hci_conn_hash_lookup_big(hdev,
@@ -2602,7 +2602,7 @@ void hci_conn_hash_flush(struct hci_dev *hdev)
 	while ((conn = list_first_entry_or_null(head,
 						struct hci_conn,
 						list)) != NULL) {
-		conn->state = BT_CLOSED;
+		hci_conn_set_state(conn, BT_CLOSED);
 		hci_disconn_cfm(conn, HCI_ERROR_LOCAL_HOST_TERM);
 		hci_conn_del(conn);
 	}

--- a/net/bluetooth/hci_core.c
+++ b/net/bluetooth/hci_core.c
@@ -68,7 +68,7 @@ static struct hci_dev *__hci_dev_get(int index, int *srcu_index)
 {
 	struct hci_dev *hdev = NULL, *d;
 
-	BT_DBG("%d", index);
+	bt_dev_dbg(hdev, "%d", index);
 
 	if (index < 0)
 		return NULL;
@@ -168,7 +168,7 @@ struct inquiry_entry *hci_inquiry_cache_lookup(struct hci_dev *hdev,
 	struct discovery_state *cache = &hdev->discovery;
 	struct inquiry_entry *e;
 
-	BT_DBG("cache %p, %pMR", cache, bdaddr);
+	bt_dev_dbg(hdev, "cache %p, %pMR", cache, bdaddr);
 
 	list_for_each_entry(e, &cache->all, all) {
 		if (!bacmp(&e->data.bdaddr, bdaddr))
@@ -184,7 +184,7 @@ struct inquiry_entry *hci_inquiry_cache_lookup_unknown(struct hci_dev *hdev,
 	struct discovery_state *cache = &hdev->discovery;
 	struct inquiry_entry *e;
 
-	BT_DBG("cache %p, %pMR", cache, bdaddr);
+	bt_dev_dbg(hdev, "cache %p, %pMR", cache, bdaddr);
 
 	list_for_each_entry(e, &cache->unknown, list) {
 		if (!bacmp(&e->data.bdaddr, bdaddr))
@@ -201,7 +201,7 @@ struct inquiry_entry *hci_inquiry_cache_lookup_resolve(struct hci_dev *hdev,
 	struct discovery_state *cache = &hdev->discovery;
 	struct inquiry_entry *e;
 
-	BT_DBG("cache %p bdaddr %pMR state %d", cache, bdaddr, state);
+	bt_dev_dbg(hdev, "cache %p bdaddr %pMR state %d", cache, bdaddr, state);
 
 	list_for_each_entry(e, &cache->resolve, list) {
 		if (!bacmp(bdaddr, BDADDR_ANY) && e->name_state == state)
@@ -239,7 +239,7 @@ u32 hci_inquiry_cache_update(struct hci_dev *hdev, struct inquiry_data *data,
 	struct inquiry_entry *ie;
 	u32 flags = 0;
 
-	BT_DBG("cache %p, %pMR", cache, &data->bdaddr);
+	bt_dev_dbg(hdev, "cache %p, %pMR", cache, &data->bdaddr);
 
 	hci_remove_remote_oob_data(hdev, &data->bdaddr, BDADDR_BREDR);
 
@@ -318,7 +318,7 @@ static int inquiry_cache_dump(struct hci_dev *hdev, int num, __u8 *buf)
 		copied++;
 	}
 
-	BT_DBG("cache %p, copied %d", cache, copied);
+	bt_dev_dbg(hdev, "cache %p, copied %d", cache, copied);
 	return copied;
 }
 
@@ -402,7 +402,7 @@ int hci_inquiry(void __user *arg)
 	ir.num_rsp = inquiry_cache_dump(hdev, max_rsp, buf);
 	hci_dev_unlock(hdev);
 
-	BT_DBG("num_rsp %d", ir.num_rsp);
+	bt_dev_dbg(hdev, "num_rsp %d", ir.num_rsp);
 
 	if (!copy_to_user(ptr, &ir, sizeof(ir))) {
 		ptr += sizeof(ir);
@@ -423,7 +423,7 @@ static int hci_dev_do_open(struct hci_dev *hdev)
 {
 	int ret = 0;
 
-	BT_DBG("%s %p", hdev->name, hdev);
+	bt_dev_dbg(hdev, "%s %p", hdev->name, hdev);
 
 	hci_req_sync_lock(hdev);
 
@@ -494,7 +494,7 @@ int hci_dev_do_close(struct hci_dev *hdev)
 {
 	int err;
 
-	BT_DBG("%s %p", hdev->name, hdev);
+	bt_dev_dbg(hdev, "%s %p", hdev->name, hdev);
 
 	hci_req_sync_lock(hdev);
 
@@ -534,7 +534,7 @@ static int hci_dev_do_reset(struct hci_dev *hdev)
 {
 	int ret;
 
-	BT_DBG("%s %p", hdev->name, hdev);
+	bt_dev_dbg(hdev, "%s %p", hdev->name, hdev);
 
 	hci_req_sync_lock(hdev);
 
@@ -644,7 +644,7 @@ static void hci_update_passive_scan_state(struct hci_dev *hdev, u8 scan)
 {
 	bool conn_changed, discov_changed;
 
-	BT_DBG("%s scan 0x%02x", hdev->name, scan);
+	bt_dev_dbg(hdev, "%s scan 0x%02x", hdev->name, scan);
 
 	if ((scan & SCAN_PAGE))
 		conn_changed = !hci_dev_test_and_set_flag(hdev,
@@ -888,7 +888,7 @@ static int hci_dev_do_poweroff(struct hci_dev *hdev)
 {
 	int err;
 
-	BT_DBG("%s %p", hdev->name, hdev);
+	bt_dev_dbg(hdev, "%s %p", hdev->name, hdev);
 
 	hci_req_sync_lock(hdev);
 
@@ -904,7 +904,7 @@ static int hci_rfkill_set_block(void *data, bool blocked)
 	struct hci_dev *hdev = data;
 	int err;
 
-	BT_DBG("%p name %s blocked %d", hdev, hdev->name, blocked);
+	bt_dev_dbg(hdev, "%p name %s blocked %d", hdev, hdev->name, blocked);
 
 	if (hci_dev_test_flag(hdev, HCI_USER_CHANNEL))
 		return -EBUSY;
@@ -945,7 +945,7 @@ static void hci_power_on(struct work_struct *work)
 	struct hci_dev *hdev = container_of(work, struct hci_dev, power_on);
 	int err;
 
-	BT_DBG("%s", hdev->name);
+	bt_dev_dbg(hdev, "%s", hdev->name);
 
 	if (test_bit(HCI_UP, &hdev->flags) &&
 	    hci_dev_test_flag(hdev, HCI_MGMT) &&
@@ -1014,7 +1014,7 @@ static void hci_power_off(struct work_struct *work)
 	struct hci_dev *hdev = container_of(work, struct hci_dev,
 					    power_off.work);
 
-	BT_DBG("%s", hdev->name);
+	bt_dev_dbg(hdev, "%s", hdev->name);
 
 	hci_dev_do_close(hdev);
 }
@@ -1024,7 +1024,7 @@ static void hci_error_reset(struct work_struct *work)
 	struct hci_dev *hdev = container_of(work, struct hci_dev, error_reset);
 
 	hci_dev_hold(hdev);
-	BT_DBG("%s", hdev->name);
+	bt_dev_dbg(hdev, "%s", hdev->name);
 
 	if (hdev->hw_error)
 		hdev->hw_error(hdev, hdev->hw_error_code);
@@ -1291,7 +1291,7 @@ struct link_key *hci_add_link_key(struct hci_dev *hdev, struct hci_conn *conn,
 		list_add_rcu(&key->list, &hdev->link_keys);
 	}
 
-	BT_DBG("%s key for %pMR type %u", hdev->name, bdaddr, type);
+	bt_dev_dbg(hdev, "%s key for %pMR type %u", hdev->name, bdaddr, type);
 
 	/* Some buggy controller combinations generate a changed
 	 * combination key for legacy pairing even when there's no
@@ -1379,7 +1379,7 @@ int hci_remove_link_key(struct hci_dev *hdev, bdaddr_t *bdaddr)
 	if (!key)
 		return -ENOENT;
 
-	BT_DBG("%s removing %pMR", hdev->name, bdaddr);
+	bt_dev_dbg(hdev, "%s removing %pMR", hdev->name, bdaddr);
 
 	list_del_rcu(&key->list);
 	kfree_rcu(key, rcu);
@@ -1396,7 +1396,7 @@ int hci_remove_ltk(struct hci_dev *hdev, bdaddr_t *bdaddr, u8 bdaddr_type)
 		if (bacmp(bdaddr, &k->bdaddr) || k->bdaddr_type != bdaddr_type)
 			continue;
 
-		BT_DBG("%s removing %pMR", hdev->name, bdaddr);
+		bt_dev_dbg(hdev, "%s removing %pMR", hdev->name, bdaddr);
 
 		list_del_rcu(&k->list);
 		kfree_rcu(k, rcu);
@@ -1414,7 +1414,7 @@ void hci_remove_irk(struct hci_dev *hdev, bdaddr_t *bdaddr, u8 addr_type)
 		if (bacmp(bdaddr, &k->bdaddr) || k->addr_type != addr_type)
 			continue;
 
-		BT_DBG("%s removing %pMR", hdev->name, bdaddr);
+		bt_dev_dbg(hdev, "%s removing %pMR", hdev->name, bdaddr);
 
 		list_del_rcu(&k->list);
 		kfree_rcu(k, rcu);
@@ -1523,7 +1523,7 @@ int hci_remove_remote_oob_data(struct hci_dev *hdev, bdaddr_t *bdaddr,
 	if (!data)
 		return -ENOENT;
 
-	BT_DBG("%s removing %pMR (%u)", hdev->name, bdaddr, bdaddr_type);
+	bt_dev_dbg(hdev, "removing %pMR (%u)", bdaddr, bdaddr_type);
 
 	list_del(&data->list);
 	kfree(data);
@@ -1582,7 +1582,7 @@ int hci_add_remote_oob_data(struct hci_dev *hdev, bdaddr_t *bdaddr,
 			data->present = 0x01;
 	}
 
-	BT_DBG("%s for %pMR", hdev->name, bdaddr);
+	bt_dev_dbg(hdev, "for %pMR", bdaddr);
 
 	return 0;
 }
@@ -1639,7 +1639,7 @@ int hci_remove_adv_instance(struct hci_dev *hdev, u8 instance)
 	if (!adv_instance)
 		return -ENOENT;
 
-	BT_DBG("%s removing %dMR", hdev->name, instance);
+	bt_dev_dbg(hdev, "removing %dMR", instance);
 
 	if (hdev->cur_adv_instance == instance) {
 		if (hdev->adv_instance_timeout) {
@@ -1759,7 +1759,7 @@ struct adv_info *hci_add_adv_instance(struct hci_dev *hdev, u8 instance,
 
 	INIT_DELAYED_WORK(&adv->rpa_expired_cb, adv_instance_rpa_expired);
 
-	BT_DBG("%s for %dMR", hdev->name, instance);
+	bt_dev_dbg(hdev, "for %dMR", instance);
 
 	return adv;
 }
@@ -2293,7 +2293,7 @@ struct hci_conn_params *hci_conn_params_add(struct hci_dev *hdev,
 	params->supervision_timeout = hdev->le_supv_timeout;
 	params->auto_connect = HCI_AUTO_CONN_DISABLED;
 
-	BT_DBG("addr %pMR (type %u)", addr, addr_type);
+	bt_dev_dbg(hdev, "addr %pMR (type %u)", addr, addr_type);
 
 	return params;
 }
@@ -2324,7 +2324,7 @@ void hci_conn_params_del(struct hci_dev *hdev, bdaddr_t *addr, u8 addr_type)
 
 	hci_update_passive_scan(hdev);
 
-	BT_DBG("addr %pMR (type %u)", addr, addr_type);
+	bt_dev_dbg(hdev, "addr %pMR (type %u)", addr, addr_type);
 }
 
 /* This function requires the caller holds hdev->lock */
@@ -2347,7 +2347,7 @@ void hci_conn_params_clear_disabled(struct hci_dev *hdev)
 		hci_conn_params_free(params);
 	}
 
-	BT_DBG("All LE disabled connection parameters were removed");
+	bt_dev_dbg(hdev, "All LE disabled connection parameters were removed");
 }
 
 /* This function requires the caller holds hdev->lock */
@@ -2358,7 +2358,7 @@ static void hci_conn_params_clear_all(struct hci_dev *hdev)
 	list_for_each_entry_safe(params, tmp, &hdev->le_conn_params, list)
 		hci_conn_params_free(params);
 
-	BT_DBG("All LE connection parameters were removed");
+	bt_dev_dbg(hdev, "All LE connection parameters were removed");
 }
 
 /* Copy the Identity Address of the controller.
@@ -2599,7 +2599,7 @@ int hci_register_dev(struct hci_dev *hdev)
 	hdev->name = dev_name(&hdev->dev);
 	hdev->id = id;
 
-	BT_DBG("%p name %s bus %d", hdev, hdev->name, hdev->bus);
+	bt_dev_dbg(hdev, "bus %d", hdev->bus);
 
 	hdev->workqueue = alloc_ordered_workqueue("%s", WQ_HIGHPRI, hdev->name);
 	if (!hdev->workqueue) {
@@ -2689,7 +2689,7 @@ EXPORT_SYMBOL(hci_register_dev);
 /* Unregister HCI device */
 void hci_unregister_dev(struct hci_dev *hdev)
 {
-	BT_DBG("%p name %s bus %d", hdev, hdev->name, hdev->bus);
+	bt_dev_dbg(hdev, "bus %d", hdev->bus);
 
 	mutex_lock(&hdev->unregister_lock);
 	hci_dev_set_flag(hdev, HCI_UNREGISTER);
@@ -3039,8 +3039,8 @@ static int hci_send_frame(struct hci_dev *hdev, struct sk_buff *skb)
 {
 	int err;
 
-	BT_DBG("%s type %d len %d", hdev->name, hci_skb_pkt_type(skb),
-	       skb->len);
+	bt_dev_dbg(hdev, "skb %p type %d len %d", skb, hci_skb_pkt_type(skb),
+		   skb->len);
 
 	/* Time stamp */
 	__net_timestamp(skb);
@@ -3093,7 +3093,7 @@ int hci_send_cmd(struct hci_dev *hdev, __u16 opcode, __u32 plen,
 {
 	struct sk_buff *skb;
 
-	BT_DBG("%s opcode 0x%4.4x plen %d", hdev->name, opcode, plen);
+	bt_dev_dbg(hdev, "opcode 0x%4.4x plen %d", opcode, plen);
 
 	skb = hci_cmd_sync_alloc(hdev, opcode, plen, param, NULL);
 	if (!skb) {
@@ -3234,12 +3234,12 @@ static void hci_queue_acl(struct hci_chan *chan, struct sk_buff_head *queue,
 	list = skb_shinfo(skb)->frag_list;
 	if (!list) {
 		/* Non fragmented */
-		BT_DBG("%s nonfrag skb %p len %d", hdev->name, skb, skb->len);
+		bt_dev_dbg(hdev, "nonfrag skb %p len %d", skb, skb->len);
 
 		skb_queue_tail(queue, skb);
 	} else {
 		/* Fragmented */
-		BT_DBG("%s frag %p len %d", hdev->name, skb, skb->len);
+		bt_dev_dbg(hdev, "frag %p len %d", skb, skb->len);
 
 		skb_shinfo(skb)->frag_list = NULL;
 
@@ -3260,7 +3260,7 @@ static void hci_queue_acl(struct hci_chan *chan, struct sk_buff_head *queue,
 			hci_skb_pkt_type(skb) = HCI_ACLDATA_PKT;
 			hci_add_acl_hdr(skb, conn->handle, flags);
 
-			BT_DBG("%s frag %p len %d", hdev->name, skb, skb->len);
+			bt_dev_dbg(hdev, "frag %p len %d", skb, skb->len);
 
 			__skb_queue_tail(queue, skb);
 		} while (list);
@@ -3273,7 +3273,7 @@ void hci_send_acl(struct hci_chan *chan, struct sk_buff *skb, __u16 flags)
 {
 	struct hci_dev *hdev = chan->conn->hdev;
 
-	BT_DBG("%s chan %p flags 0x%4.4x", hdev->name, chan, flags);
+	bt_dev_dbg(hdev, "chan %p skb %p flags 0x%4.4x", chan, skb, flags);
 
 	hci_queue_acl(chan, &chan->data_q, skb, flags);
 
@@ -3286,7 +3286,7 @@ void hci_send_sco(struct hci_conn *conn, struct sk_buff *skb)
 	struct hci_dev *hdev = conn->hdev;
 	struct hci_sco_hdr hdr;
 
-	BT_DBG("%s len %d", hdev->name, skb->len);
+	bt_dev_dbg(hdev, "hcon %p skb %p len %d", conn, skb, skb->len);
 
 	hdr.handle = cpu_to_le16(conn->handle);
 	hdr.dlen   = skb->len;
@@ -3333,12 +3333,12 @@ static void hci_queue_iso(struct hci_conn *conn, struct sk_buff_head *queue,
 
 	if (!list) {
 		/* Non fragmented */
-		BT_DBG("%s nonfrag skb %p len %d", hdev->name, skb, skb->len);
+		bt_dev_dbg(hdev, "nonfrag skb %p len %d", skb, skb->len);
 
 		skb_queue_tail(queue, skb);
 	} else {
 		/* Fragmented */
-		BT_DBG("%s frag %p len %d", hdev->name, skb, skb->len);
+		bt_dev_dbg(hdev, "frag %p len %d", skb, skb->len);
 
 		skb_shinfo(skb)->frag_list = NULL;
 
@@ -3352,7 +3352,7 @@ static void hci_queue_iso(struct hci_conn *conn, struct sk_buff_head *queue,
 						   0x00);
 			hci_add_iso_hdr(skb, conn->handle, flags);
 
-			BT_DBG("%s frag %p len %d", hdev->name, skb, skb->len);
+			bt_dev_dbg(hdev, "frag %p len %d", skb, skb->len);
 
 			__skb_queue_tail(queue, skb);
 		} while (list);
@@ -3363,7 +3363,7 @@ void hci_send_iso(struct hci_conn *conn, struct sk_buff *skb)
 {
 	struct hci_dev *hdev = conn->hdev;
 
-	BT_DBG("%s len %d", hdev->name, skb->len);
+	bt_dev_dbg(hdev, "hcon %p skb %p len %d", conn, skb, skb->len);
 
 	hci_queue_iso(conn, &conn->data_q, skb);
 
@@ -3445,7 +3445,7 @@ static struct hci_conn *hci_low_sent(struct hci_dev *hdev, __u8 type,
 
 	hci_quote_sent(conn, num, quote);
 
-	BT_DBG("conn %p quote %d", conn, *quote);
+	bt_dev_dbg(hdev, "hcon %p quote %d", conn, *quote);
 	return conn;
 }
 
@@ -3479,7 +3479,7 @@ static struct hci_chan *hci_chan_sent(struct hci_dev *hdev, __u8 type,
 	struct hci_conn *conn;
 	int conn_num = 0;
 
-	BT_DBG("%s", hdev->name);
+	bt_dev_dbg(hdev, "");
 
 	rcu_read_lock();
 
@@ -3529,7 +3529,7 @@ static struct hci_chan *hci_chan_sent(struct hci_dev *hdev, __u8 type,
 
 	hci_quote_sent(chan->conn, num, quote);
 
-	BT_DBG("chan %p quote %d", chan, *quote);
+	bt_dev_dbg(hdev, "chan %p quote %d", chan, *quote);
 	return chan;
 }
 
@@ -3539,7 +3539,7 @@ static void hci_prio_recalculate(struct hci_dev *hdev, __u8 type)
 	struct hci_conn *conn;
 	int num = 0;
 
-	BT_DBG("%s", hdev->name);
+	bt_dev_dbg(hdev, "");
 
 	rcu_read_lock();
 
@@ -3571,8 +3571,8 @@ static void hci_prio_recalculate(struct hci_dev *hdev, __u8 type)
 
 			skb->priority = HCI_PRIO_MAX - 1;
 
-			BT_DBG("chan %p skb %p promoted to %d", chan, skb,
-			       skb->priority);
+			bt_dev_dbg(hdev, "chan %p skb %p promoted to %d", chan,
+				   skb, skb->priority);
 		}
 
 		if (hci_conn_num(hdev, type) == num)
@@ -3642,7 +3642,7 @@ static void hci_sched_sco(struct hci_dev *hdev, __u8 type)
 
 	while (*cnt && (conn = hci_low_sent(hdev, type, &quote))) {
 		while (quote-- && (skb = skb_dequeue(&conn->data_q))) {
-			BT_DBG("skb %p len %d", skb, skb->len);
+			bt_dev_dbg(hdev, "skb %p len %d", skb, skb->len);
 			hci_send_conn_frame(hdev, conn, skb);
 
 			conn->sent++;
@@ -3674,8 +3674,8 @@ static void hci_sched_acl_pkt(struct hci_dev *hdev)
 	       (chan = hci_chan_sent(hdev, ACL_LINK, &quote))) {
 		u32 priority = (skb_peek(&chan->data_q))->priority;
 		while (quote-- && (skb = skb_peek(&chan->data_q))) {
-			BT_DBG("chan %p skb %p len %d priority %u", chan, skb,
-			       skb->len, skb->priority);
+			bt_dev_dbg(hdev, "chan %p skb %p len %d priority %u",
+				   chan, skb, skb->len, skb->priority);
 
 			/* Stop if priority has changed */
 			if (skb->priority < priority)
@@ -3705,7 +3705,7 @@ static void hci_sched_acl_pkt(struct hci_dev *hdev)
 
 static void hci_sched_acl(struct hci_dev *hdev)
 {
-	BT_DBG("%s", hdev->name);
+	bt_dev_dbg(hdev, "");
 
 	/* No ACL link over BR/EDR controller */
 	if (!hci_conn_num(hdev, ACL_LINK))
@@ -3720,7 +3720,7 @@ static void hci_sched_le(struct hci_dev *hdev)
 	struct sk_buff *skb;
 	int quote, *cnt, tmp;
 
-	BT_DBG("%s", hdev->name);
+	bt_dev_dbg(hdev, "");
 
 	if (!hci_conn_num(hdev, LE_LINK))
 		return;
@@ -3733,8 +3733,8 @@ static void hci_sched_le(struct hci_dev *hdev)
 	while (*cnt && (chan = hci_chan_sent(hdev, LE_LINK, &quote))) {
 		u32 priority = (skb_peek(&chan->data_q))->priority;
 		while (quote-- && (skb = skb_peek(&chan->data_q))) {
-			BT_DBG("chan %p skb %p len %d priority %u", chan, skb,
-			       skb->len, skb->priority);
+			bt_dev_dbg(hdev, "chan %p skb %p len %d priority %u",
+				   chan, skb, skb->len, skb->priority);
 
 			/* Stop if priority has changed */
 			if (skb->priority < priority)
@@ -3766,7 +3766,7 @@ static void hci_sched_iso(struct hci_dev *hdev, __u8 type)
 	struct sk_buff *skb;
 	int quote, *cnt;
 
-	BT_DBG("%s", hdev->name);
+	bt_dev_dbg(hdev, "type %u", type);
 
 	if (!hci_conn_num(hdev, type))
 		return;
@@ -3777,7 +3777,7 @@ static void hci_sched_iso(struct hci_dev *hdev, __u8 type)
 
 	while (*cnt && (conn = hci_low_sent(hdev, type, &quote))) {
 		while (quote-- && (skb = skb_dequeue(&conn->data_q))) {
-			BT_DBG("skb %p len %d", skb, skb->len);
+			bt_dev_dbg(hdev, "skb %p len %d", skb, skb->len);
 
 			hci_send_conn_frame(hdev, conn, skb);
 			hdev->iso_last_tx = jiffies;
@@ -3795,8 +3795,8 @@ static void hci_tx_work(struct work_struct *work)
 	struct hci_dev *hdev = container_of(work, struct hci_dev, tx_work);
 	struct sk_buff *skb;
 
-	BT_DBG("%s acl %d sco %d le %d iso %d", hdev->name, hdev->acl_cnt,
-	       hdev->sco_cnt, hdev->le_cnt, hdev->iso_cnt);
+	bt_dev_dbg(hdev, "acl %d sco %d le %d iso %d", hdev->acl_cnt,
+		   hdev->sco_cnt, hdev->le_cnt, hdev->iso_cnt);
 
 	if (!hci_dev_test_flag(hdev, HCI_USER_CHANNEL)) {
 		/* Schedule queues and send stuff to HCI driver */
@@ -3974,7 +3974,7 @@ void hci_req_cmd_complete(struct hci_dev *hdev, u16 opcode, u8 status,
 	struct sk_buff *skb;
 	unsigned long flags;
 
-	BT_DBG("opcode 0x%04x status 0x%02x", opcode, status);
+	bt_dev_dbg(hdev, "opcode 0x%04x status 0x%02x", opcode, status);
 
 	/* If the completed command doesn't match the last one that was
 	 * sent we need to do special handling of it.
@@ -4039,7 +4039,7 @@ static void hci_rx_work(struct work_struct *work)
 	struct hci_dev *hdev = container_of(work, struct hci_dev, rx_work);
 	struct sk_buff *skb;
 
-	BT_DBG("%s", hdev->name);
+	bt_dev_dbg(hdev, "");
 
 	/* The kcov_remote functions used for collecting packet parsing
 	 * coverage information from this background thread and associate
@@ -4083,22 +4083,22 @@ static void hci_rx_work(struct work_struct *work)
 		/* Process frame */
 		switch (hci_skb_pkt_type(skb)) {
 		case HCI_EVENT_PKT:
-			BT_DBG("%s Event packet", hdev->name);
+			bt_dev_dbg(hdev, "Event packet");
 			hci_event_packet(hdev, skb);
 			break;
 
 		case HCI_ACLDATA_PKT:
-			BT_DBG("%s ACL data packet", hdev->name);
+			bt_dev_dbg(hdev, "ACL data packet");
 			hci_acldata_packet(hdev, skb);
 			break;
 
 		case HCI_SCODATA_PKT:
-			BT_DBG("%s SCO data packet", hdev->name);
+			bt_dev_dbg(hdev, "SCO data packet");
 			hci_scodata_packet(hdev, skb);
 			break;
 
 		case HCI_ISODATA_PKT:
-			BT_DBG("%s ISO data packet", hdev->name);
+			bt_dev_dbg(hdev, "ISO data packet");
 			hci_isodata_packet(hdev, skb);
 			break;
 
@@ -4145,8 +4145,8 @@ static void hci_cmd_work(struct work_struct *work)
 	struct hci_dev *hdev = container_of(work, struct hci_dev, cmd_work);
 	struct sk_buff *skb;
 
-	BT_DBG("%s cmd_cnt %d cmd queued %d", hdev->name,
-	       atomic_read(&hdev->cmd_cnt), skb_queue_len(&hdev->cmd_q));
+	bt_dev_dbg(hdev, "cmd_cnt %d cmd queued %d",
+		   atomic_read(&hdev->cmd_cnt), skb_queue_len(&hdev->cmd_q));
 
 	/* Send queued commands */
 	if (atomic_read(&hdev->cmd_cnt)) {

--- a/net/bluetooth/hci_event.c
+++ b/net/bluetooth/hci_event.c
@@ -947,8 +947,8 @@ static u8 hci_cc_read_buffer_size(struct hci_dev *hdev, void *data,
 	hdev->acl_cnt = hdev->acl_pkts;
 	hdev->sco_cnt = hdev->sco_pkts;
 
-	BT_DBG("%s acl mtu %d:%d sco mtu %d:%d", hdev->name, hdev->acl_mtu,
-	       hdev->acl_pkts, hdev->sco_mtu, hdev->sco_pkts);
+	bt_dev_dbg(hdev, "acl mtu %d:%d sco mtu %d:%d", hdev->acl_mtu,
+		   hdev->acl_pkts, hdev->sco_mtu, hdev->sco_pkts);
 
 	if (!hdev->acl_mtu || !hdev->acl_pkts)
 		return HCI_ERROR_INVALID_PARAMETERS;
@@ -1214,7 +1214,7 @@ static u8 hci_cc_le_read_buffer_size(struct hci_dev *hdev, void *data,
 
 	hdev->le_cnt = hdev->le_pkts;
 
-	BT_DBG("%s le mtu %d:%d", hdev->name, hdev->le_mtu, hdev->le_pkts);
+	bt_dev_dbg(hdev, "le mtu %d:%d", hdev->le_mtu, hdev->le_pkts);
 
 	if (hdev->le_mtu && hdev->le_mtu < HCI_MIN_LE_MTU)
 		return HCI_ERROR_INVALID_PARAMETERS;
@@ -1227,7 +1227,7 @@ static u8 hci_cc_le_read_local_features(struct hci_dev *hdev, void *data,
 {
 	struct hci_rp_le_read_local_features *rp = data;
 
-	BT_DBG("%s status 0x%2.2x", hdev->name, rp->status);
+	bt_dev_dbg(hdev, "status 0x%2.2x", rp->status);
 
 	if (rp->status)
 		return rp->status;
@@ -2921,7 +2921,7 @@ static void hci_cs_switch_role(struct hci_dev *hdev, u8 status)
 	struct hci_cp_switch_role *cp;
 	struct hci_conn *conn;
 
-	BT_DBG("%s status 0x%2.2x", hdev->name, status);
+	bt_dev_dbg(hdev, "status 0x%2.2x", status);
 
 	if (!status)
 		return;
@@ -3753,8 +3753,8 @@ static u8 hci_cc_le_read_buffer_size_v2(struct hci_dev *hdev, void *data,
 	hdev->le_cnt  = hdev->le_pkts;
 	hdev->iso_cnt = hdev->iso_pkts;
 
-	BT_DBG("%s acl mtu %d:%d iso mtu %d:%d", hdev->name, hdev->acl_mtu,
-	       hdev->acl_pkts, hdev->iso_mtu, hdev->iso_pkts);
+	bt_dev_dbg(hdev, "acl mtu %d:%d iso mtu %d:%d", hdev->acl_mtu,
+		   hdev->acl_pkts, hdev->iso_mtu, hdev->iso_pkts);
 
 	if (hdev->le_mtu && hdev->le_mtu < HCI_MIN_LE_MTU)
 		return HCI_ERROR_INVALID_PARAMETERS;
@@ -5336,8 +5336,9 @@ static void hci_user_confirm_request_evt(struct hci_dev *hdev, void *data,
 			goto confirm;
 		}
 
-		BT_DBG("Auto-accept of user confirmation with %ums delay",
-		       hdev->auto_accept_delay);
+		bt_dev_dbg(hdev,
+			   "Auto-accept of user confirmation with %ums delay",
+			   hdev->auto_accept_delay);
 
 		if (hdev->auto_accept_delay > 0) {
 			int delay = msecs_to_jiffies(hdev->auto_accept_delay);
@@ -5967,7 +5968,7 @@ static struct hci_conn *check_pending_le_conn(struct hci_dev *hdev,
 		 */
 		break;
 	default:
-		BT_DBG("Failed to connect: err %ld", PTR_ERR(conn));
+		bt_dev_dbg(hdev, "Failed to connect: err %ld", PTR_ERR(conn));
 		return NULL;
 	}
 
@@ -6861,7 +6862,7 @@ static void hci_le_create_big_complete_evt(struct hci_dev *hdev, void *data,
 	struct hci_conn *conn;
 	__u8 i = 0;
 
-	BT_DBG("%s status 0x%2.2x", hdev->name, ev->status);
+	bt_dev_dbg(hdev, "status 0x%2.2x", ev->status);
 
 	if (!hci_le_ev_skb_pull(hdev, skb, HCI_EVT_LE_CREATE_BIG_COMPLETE,
 				flex_array_size(ev, bis_handle, ev->num_bis)))
@@ -7239,8 +7240,8 @@ static bool hci_get_cmd_complete(struct hci_dev *hdev, u16 opcode,
 		return false;
 
 	if (opcode != __le16_to_cpu(ev->opcode)) {
-		BT_DBG("opcode doesn't match (0x%2.2x != 0x%2.2x)", opcode,
-		       __le16_to_cpu(ev->opcode));
+		bt_dev_dbg(hdev, "opcode doesn't match (0x%2.2x != 0x%2.2x)",
+			   opcode, __le16_to_cpu(ev->opcode));
 		return false;
 	}
 

--- a/net/bluetooth/hci_sock.c
+++ b/net/bluetooth/hci_sock.c
@@ -205,7 +205,7 @@ void hci_send_to_sock(struct hci_dev *hdev, struct sk_buff *skb)
 	struct sock *sk;
 	struct sk_buff *skb_copy = NULL;
 
-	BT_DBG("hdev %p len %d", hdev, skb->len);
+	bt_dev_dbg(hdev, "skb %p len %d", skb, skb->len);
 
 	read_lock(&hci_sk_list.lock);
 
@@ -365,7 +365,7 @@ void hci_send_to_monitor(struct hci_dev *hdev, struct sk_buff *skb)
 	if (!atomic_read(&monitor_promisc))
 		return;
 
-	BT_DBG("hdev %p len %d", hdev, skb->len);
+	bt_dev_dbg(hdev, "skb %p len %d", skb, skb->len);
 
 	switch (hci_skb_pkt_type(skb)) {
 	case HCI_COMMAND_PKT:
@@ -810,7 +810,7 @@ static void hci_si_event(struct hci_dev *hdev, int type, int dlen, void *data)
 
 void hci_sock_dev_event(struct hci_dev *hdev, int event)
 {
-	BT_DBG("hdev %s event %d", hdev->name, event);
+	bt_dev_dbg(hdev, "event %d", event);
 
 	if (atomic_read(&monitor_promisc)) {
 		struct sk_buff *skb;
@@ -1625,7 +1625,7 @@ static int hci_mgmt_cmd(struct hci_mgmt_chan *chan, struct sock *sk,
 	bool var_len, no_hdev;
 	int err;
 
-	BT_DBG("got %d bytes", skb->len);
+	BT_DBG("sk %p skb %p len %u", sk, skb, skb->len);
 
 	if (skb->len < sizeof(*hdr))
 		return -EINVAL;
@@ -1655,7 +1655,7 @@ static int hci_mgmt_cmd(struct hci_mgmt_chan *chan, struct sock *sk,
 
 	if (opcode >= chan->handler_count ||
 	    chan->handlers[opcode].func == NULL) {
-		BT_DBG("Unknown op %u", opcode);
+		bt_dev_dbg(hdev, "Unknown op %u", opcode);
 		err = mgmt_cmd_status(sk, index, opcode,
 				      MGMT_STATUS_UNKNOWN_COMMAND);
 		goto done;
@@ -2200,7 +2200,7 @@ static int hci_sock_create(struct net *net, struct socket *sock, int protocol,
 {
 	struct sock *sk;
 
-	BT_DBG("sock %p", sock);
+	BT_DBG("sock %p protocol %d kern %d", sock, protocol, kern);
 
 	if (sock->type != SOCK_RAW)
 		return -ESOCKTNOSUPPORT;

--- a/net/bluetooth/hci_sync.c
+++ b/net/bluetooth/hci_sync.c
@@ -5189,7 +5189,7 @@ static void hci_pend_le_actions_clear(struct hci_dev *hdev)
 		}
 	}
 
-	BT_DBG("All LE pending actions cleared");
+	bt_dev_dbg(hdev, "All LE pending actions cleared");
 }
 
 static int hci_dev_shutdown(struct hci_dev *hdev)

--- a/net/bluetooth/hci_sync.c
+++ b/net/bluetooth/hci_sync.c
@@ -5682,7 +5682,7 @@ int hci_abort_conn_sync(struct hci_dev *hdev, struct hci_conn *conn, u8 reason)
 	 * safely.
 	 */
 	if (disconnect) {
-		conn->state = BT_CLOSED;
+		hci_conn_set_state(conn, BT_CLOSED);
 		hci_disconn_cfm(conn, reason);
 		hci_conn_del(conn);
 	} else {
@@ -6518,7 +6518,7 @@ static int hci_le_create_conn_sync(struct hci_dev *hdev, void *data)
 	bt_dev_dbg(hdev, "conn %p", conn);
 
 	clear_bit(HCI_CONN_SCANNING, &conn->flags);
-	conn->state = BT_CONNECT;
+	hci_conn_set_state(conn, BT_CONNECT);
 
 	/* If requested to connect as peripheral use directed advertising */
 	if (conn->role == HCI_ROLE_SLAVE) {
@@ -6858,7 +6858,7 @@ static int hci_acl_create_conn_sync(struct hci_dev *hdev, void *data)
 			bt_dev_warn(hdev, "Failed to cancel inquiry %d", err);
 	}
 
-	conn->state = BT_CONNECT;
+	hci_conn_set_state(conn, BT_CONNECT);
 	conn->out = true;
 	conn->role = HCI_ROLE_MASTER;
 

--- a/net/bluetooth/iso.c
+++ b/net/bluetooth/iso.c
@@ -1462,7 +1462,7 @@ static void iso_conn_defer_accept(struct hci_conn *conn)
 
 	BT_DBG("conn %p", conn);
 
-	conn->state = BT_CONFIG;
+	hci_conn_set_state(conn, BT_CONFIG);
 
 	cp.handle = cpu_to_le16(conn->handle);
 

--- a/net/bluetooth/sco.c
+++ b/net/bluetooth/sco.c
@@ -830,7 +830,7 @@ static void sco_conn_defer_accept(struct hci_conn *conn, u16 setting)
 
 	BT_DBG("conn %p", conn);
 
-	conn->state = BT_CONFIG;
+	hci_conn_set_state(conn, BT_CONFIG);
 
 	if (!lmp_esco_capable(hdev)) {
 		struct hci_cp_accept_conn_req cp;


### PR DESCRIPTION
From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>

This converts instances of BT_DBG to bt_dev_dbg when logging to a
specific hci_dev this is preferable since it does prints the name by
default.

Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
---
 net/bluetooth/hci_core.c | 134 +++++++++++++++++++--------------------
 1 file changed, 67 insertions(+), 67 deletions(-)