### PR TITLE
[PW_SID:1002134] Bluetooth: hci_bcm: use str_low_high() helper instead of ternary operator

### DIFF
--- a/drivers/bluetooth/hci_bcm.c
+++ b/drivers/bluetooth/hci_bcm.c
@@ -26,6 +26,7 @@
 #include <linux/dmi.h>
 #include <linux/pm_runtime.h>
 #include <linux/serdev.h>
+#include <linux/string_choices.h>
 
 #include <net/bluetooth/bluetooth.h>
 #include <net/bluetooth/hci_core.h>
@@ -1213,7 +1214,7 @@ static int bcm_acpi_probe(struct bcm_device *dev)
 	if (irq_polarity != -1) {
 		dev->irq_active_low = irq_polarity;
 		dev_warn(dev->dev, "Overwriting IRQ polarity to active %s by module-param\n",
-			 dev->irq_active_low ? "low" : "high");
+			 str_low_high(dev->irq_active_low));
 	}
 
 	return 0;


### PR DESCRIPTION
Replace the ternary operator: 'dev->irq_active_low ? "low" : "high"'
with the str_low_high() helper function. This enhances code readability
and maintains consistency.

Signed-off-by: Nai-Chen Cheng <bleach1827@gmail.com>
---
 drivers/bluetooth/hci_bcm.c | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)


---
base-commit: f83a4f2a4d8c485922fba3018a64fc8f4cfd315f
change-id: 20250914-bluetooth-hci_bcm-string-choice-helper-aae05c9c18b2

Best regards,