### PR TITLE
[PW_SID:1008429] Bluetooth: ISO/SCO: hold sock in recv_frame

### DIFF
--- a/net/bluetooth/iso.c
+++ b/net/bluetooth/iso.c
@@ -572,6 +572,7 @@ static void iso_recv_frame(struct iso_conn *conn, struct sk_buff *skb)
 
 	iso_conn_lock(conn);
 	sk = conn->sk;
+	sock_hold(sk);
 	iso_conn_unlock(conn);
 
 	if (!sk)
@@ -583,10 +584,13 @@ static void iso_recv_frame(struct iso_conn *conn, struct sk_buff *skb)
 		goto drop;
 
 	if (!sock_queue_rcv_skb(sk, skb))
-		return;
+		goto done;
 
 drop:
 	kfree_skb(skb);
+done:
+	if (sk)
+		sock_put(sk);
 }
 
 /* -------- Socket interface ---------- */

--- a/net/bluetooth/sco.c
+++ b/net/bluetooth/sco.c
@@ -402,6 +402,7 @@ static void sco_recv_frame(struct sco_conn *conn, struct sk_buff *skb)
 
 	sco_conn_lock(conn);
 	sk = conn->sk;
+	sock_hold(sk);
 	sco_conn_unlock(conn);
 
 	if (!sk)
@@ -413,10 +414,13 @@ static void sco_recv_frame(struct sco_conn *conn, struct sk_buff *skb)
 		goto drop;
 
 	if (!sock_queue_rcv_skb(sk, skb))
-		return;
+		goto done;
 
 drop:
 	kfree_skb(skb);
+done:
+	if (sk)
+		sock_put(sk);
 }
 
 /* -------- Socket interface ---------- */


### PR DESCRIPTION
In sco_recv_frame(), sk is accessed without holding lock or refcount.
conn->sk is obtained under lock, it guards data race on conn->sk versus
sco_chan_del() / sco_sock_kill(), but does not prevent sk from being
destroyed after unlock.  Similarly for ISO. (L2CAP holds chan_lock so is
OK).

Use sock_hold()/sock_put() during the section sk is accessed.

Simultaneous socket release in theory could cause UAF here, but probably
hard to hit in practice.

Fixes: ccf74f2390d60 ("Bluetooth: Add BTPROTO_ISO socket type")
Fixes: eb5a4de80f266 ("Bluetooth: Remove sco_chan_get helper function")
Signed-off-by: Pauli Virtanen <pav@iki.fi>
---
 net/bluetooth/iso.c | 6 +++++-
 net/bluetooth/sco.c | 6 +++++-
 2 files changed, 10 insertions(+), 2 deletions(-)