### PR TITLE
[PW_SID:1092685] Bluetooth: btmtk: set HCI_QUIRK_BROKEN_ENHANCED_SETUP_SYNC_CONN for MT6639

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          path: src/src
+
+      - name: CI
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: ci
+          base_folder: src
+          space: kernel
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,36 @@
+name: Snyc
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Sync Repo
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: sync
+          upstream_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sync Patchwork
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: patchwork
+          space: kernel
+          github_token: ${{ secrets.ACTION_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/drivers/bluetooth/btmtk.c
+++ b/drivers/bluetooth/btmtk.c
@@ -1417,6 +1417,19 @@ int btmtk_usb_setup(struct hci_dev *hdev)
 		hci_set_msft_opcode(hdev, 0xFD30);
 		hci_set_aosp_capable(hdev);
 
+		/* MT6639 firmware advertises the HCI Enhanced Setup
+		 * Synchronous Connection command (opcode 0x043D) in its
+		 * supported-commands bitmap, but actually rejects it at
+		 * runtime, breaking mSBC wideband HFP (the headset mic
+		 * captures pure silence). The Windows MediaTek driver
+		 * works around this by falling back to the classic Setup
+		 * Synchronous Connection command (opcode 0x0428); setting
+		 * this quirk makes the BR/EDR core do the same fallback.
+		 */
+		if (dev_id == 0x6639)
+			hci_set_quirk(hdev,
+				      HCI_QUIRK_BROKEN_ENHANCED_SETUP_SYNC_CONN);
+
 		/* Clear BTMTK_FIRMWARE_DL_RETRY if setup successfully */
 		test_and_clear_bit(BTMTK_FIRMWARE_DL_RETRY, &btmtk_data->flags);
 


### PR DESCRIPTION
The MediaTek MT6639 Bluetooth controller (the BT half of the MT7925/MT7927
WiFi 7 combo silicon shipped on motherboards such as the ASUS ProArt
X870E-CREATOR WIFI) advertises support for HCI Enhanced Setup Synchronous
Connection (opcode 0x043D) in its supported-commands bitmap, but rejects
the command at runtime.

This breaks HFP wideband-speech (mSBC): when a Bluetooth headset is
connected and the kernel attempts to set up an mSBC eSCO link, the
controller responds with an error and the kernel logs:

  Bluetooth: hciN: HCI Enhanced Setup Synchronous Connection command \
      is advertised, but not supported.

User-visible symptom: the headset microphone captures pure silence in
HFP mode, while A2DP playback works normally. This reproduces on every
MT6639-based machine seen so far.

A Bluetooth HCI trace captured on Windows on the same hardware (ASUS
X870E-CREATOR with the MediaTek WHQL driver, recorded via the ETW
BTHPORT provider during an HFP wideband recording session) shows that
the Windows driver works around the same firmware bug by issuing the
classic Setup Synchronous Connection command (opcode 0x0428) with
Transparent air-mode parameters. The classic command sets up an mSBC
eSCO link successfully, and the headset streams 16 kHz mono wideband
audio over it as expected.

HCI_QUIRK_BROKEN_ENHANCED_SETUP_SYNC_CONN exists in the BR/EDR HCI core
for exactly this case: when set, hci_setup_sync_conn() falls back to
the classic Setup Synchronous Connection command with the same
parameters. Setting the quirk for MT6639 makes Linux do what Windows
does, restoring wideband HFP.

The change is scoped to dev_id == 0x6639 to keep it hardware-confirmed
on the chip where the bug has been reproduced and the Windows fallback
has been observed. Sibling MT79xx variants (MT7921 / MT7922 / MT7925 /
MT7961) exhibit the same dmesg signature in community bug reports; if
the same fallback proves correct for them, extending the quirk to
those chip IDs is straightforward follow-up.

Verification on an ASUS ProArt X870E-CREATOR WIFI:

  - Before patch: profile switch to headset-head-unit (mSBC) is
    accepted by PipeWire, but the kernel issues HCI_OP_ENHANCED_SETUP_
    SYNC_CONN (0x043D), the controller refuses it, no eSCO link is
    established, the mic captures pure silence.
  - After patch: the kernel issues HCI_OP_SETUP_SYNC_CONN (0x0428)
    with Air Coding Format = Transparent. The controller responds
    Synchronous Connect Complete: Status Success, Link type eSCO,
    Air mode Transparent. SCO data flows over the link.

Signed-off-by: Silviu Sandulache <silviu.sandulache@gmail.com>
---
 drivers/bluetooth/btmtk.c | 13 +++++++++++++
 1 file changed, 13 insertions(+)