### PR TITLE
[PW_SID:1096820] Bluetooth: btusb: Add Realtek RTL8852BE BT 0x04c5/0x1670 (Fujitsu)

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,4 @@
+--summary-file
+--show-types
+
+--ignore UNKNOWN_COMMIT_ID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI for Pull Request
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          path: src/src
+
+      - name: CI
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: ci
+          base_folder: src
+          space: kernel
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,36 @@
+name: Snyc
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  sync_repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+
+      - name: Sync Repo
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: sync
+          upstream_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/bluetooth/bluetooth-next.git"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sync_patchwork:
+    needs: sync_repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sync Patchwork
+        uses: tedd-an/bzcafe@dev
+        with:
+          task: patchwork
+          space: kernel
+          github_token: ${{ secrets.ACTION_TOKEN }}
+          email_token: ${{ secrets.EMAIL_TOKEN }}
+          patchwork_token: ${{ secrets.PATCHWORK_TOKEN }}
+          patchwork_user: ${{ secrets.PATCHWORK_USER }}

--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -544,6 +544,8 @@ static const struct usb_device_id quirks_table[] = {
 						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x04c5, 0x165c), .driver_info = BTUSB_REALTEK |
 						     BTUSB_WIDEBAND_SPEECH },
+	{ USB_DEVICE(0x04c5, 0x1670), .driver_info = BTUSB_REALTEK |
+						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x04ca, 0x4006), .driver_info = BTUSB_REALTEK |
 						     BTUSB_WIDEBAND_SPEECH },
 	{ USB_DEVICE(0x0cb8, 0xc549), .driver_info = BTUSB_REALTEK |


### PR DESCRIPTION
The Fujitsu LIFEBOOK E5512A ships with a Realtek RTL8852BE combo chip
whose Bluetooth half is exposed as a Fujitsu-rebranded USB device
0x04c5/0x1670. Without this entry in quirks_table, btusb binds via the
generic Bluetooth class match but never sets the BTUSB_REALTEK quirk,
so btrtl_setup_realtek() is never called and the rtl8852bu firmware
patch is never loaded. As a result HCI works (hci0 UP RUNNING), but
RF reception is non-functional: inquiry and LE scan find nothing and
pairing is impossible.

Other Fujitsu OEM rebrands of Realtek chips are already in quirks_table
(0x04c5/0x165c, 0x04c5/0x1675, 0x04c5/0x161f). Add 0x04c5/0x1670 in
the same "Realtek 8852BE Bluetooth devices" block, alongside 0x04c5/0x165c.

USB descriptors of the device:

    Bus 001 Device 004: ID 04c5:1670 Fujitsu, Ltd Bluetooth Radio
      bDeviceClass          224 Wireless
      bDeviceSubClass         1 Radio Frequency
      bDeviceProtocol         1 Bluetooth
      iManufacturer           1 Realtek
      iProduct                2 Bluetooth Radio

Tested on Fujitsu LIFEBOOK E5512A (Ryzen 7 PRO 5875U, Ubuntu 25.10,
kernel 6.17.0-29-generic). After the patch:

  Bluetooth: hci0: RTL: examining hci_ver=0b hci_rev=000b lmp_ver=0b lmp_subver=8852
  Bluetooth: hci0: RTL: rom_version status=0 version=1
  Bluetooth: hci0: RTL: loading rtl_bt/rtl8852bu_fw.bin
  Bluetooth: hci0: RTL: loading rtl_bt/rtl8852bu_config.bin
  Bluetooth: hci0: RTL: fw version 0x098b154b
  Bluetooth: hci0: AOSP extensions version v1.00

Scanning, pairing and A2DP audio playback to BT headphones all work
after the firmware patch is loaded.

Signed-off-by: Jaroslav Srba <jarys.cz@gmail.com>
---
 drivers/bluetooth/btusb.c | 2 ++
 1 file changed, 2 insertions(+)