### PR TITLE
[PW_SID:1103634] [v2] Bluetooth: fix memory leak in error path of hci_alloc_dev()

### DIFF
--- a/net/bluetooth/hci_sysfs.c
+++ b/net/bluetooth/hci_sysfs.c
@@ -85,8 +85,10 @@ static void bt_host_release(struct device *dev)
 
 	if (hci_dev_test_flag(hdev, HCI_UNREGISTER))
 		hci_release_dev(hdev);
-	else
+	else {
+		cleanup_srcu_struct(&hdev->srcu);
 		kfree(hdev);
+	}
 	module_put(THIS_MODULE);
 }
 


### PR DESCRIPTION
Early failures in Bluetooth HCI UART configuration leak SRCU percpu
memory.

When device initialization fails before hci_register_dev() completes,
the HCI_UNREGISTER flag is never set. As a result, when the device
reference count reaches zero, bt_host_release() evaluates this flag as
false and falls back to a direct kfree(hdev).

Because hci_release_dev() is bypassed, the SRCU struct initialized
early in hci_alloc_dev() is never cleaned up, resulting in a leak of
percpu memory.

Fix the leak by explicitly calling cleanup_srcu_struct() in the
fallback (unregistered) branch of bt_host_release() before freeing
the device.

Reported-by: syzbot+535ecc844591e50588a5@syzkaller.appspotmail.com
Tested-by: syzbot+535ecc844591e50588a5@syzkaller.appspotmail.com
Signed-off-by: Bharath Reddy <kbreddy.rpbc@gmail.com>
---
 net/bluetooth/hci_sysfs.c | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)